### PR TITLE
Daniel fda categories

### DIFF
--- a/src/app/branch/inventory/[id]/page.tsx
+++ b/src/app/branch/inventory/[id]/page.tsx
@@ -7,22 +7,11 @@ import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import { ArrowLeftIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
 
 export default function BranchEditMedicationPage() {
   const { t } = useTranslation();

--- a/src/app/branch/inventory/add/page.tsx
+++ b/src/app/branch/inventory/add/page.tsx
@@ -1,119 +1,33 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
-import api from '@/lib/api';
-import toast from 'react-hot-toast';
-import LoadingSpinner from '@/components/shared/LoadingSpinner';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeftIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { useMedicationForm } from '@/hooks/useMedicationForm';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
-
 export default function BranchAddMedicationPage() {
-  const { t } = useTranslation();
-  const router = useRouter();
-  const [loading, setLoading] = useState(false);
-  const [branchId, setBranchId] = useState('');
-  const [branchName, setBranchName] = useState('');
-  const [branchLoading, setBranchLoading] = useState(true);
-  const [backendReady, setBackendReady] = useState(true);
+  const { t }    = useTranslation();
+  const router   = useRouter();
 
-  const [form, setForm] = useState({
-    name: '',
-    category: FDA_CATEGORIES[0],
-    chemicalName: '',
-    description: '',
-    price: '',
-    quantity: '',
-    lowStockThreshold: '10',
-    requiresPrescription: false,
-  });
+  const {
+    form, setForm,
+    loading,
+    backendPending,
+    handleSubmit,
+  } = useMedicationForm('branch');
 
-  useEffect(() => {
-    // Branch manager belongs to one branch — fetch it from their profile
-    // GET /staff/profile/me is not available for BRANCH_MANAGER
-    // Instead we use GET /branches/my-branches which is restricted to PHARMACY only
-    // BACKEND NOTE: the backend team should expose the manager's branch via auth context
-    // For now we rely on the dashboard data which fetches /attendance/summary (includes branchId)
-    // As a fallback we read from the JWT-cached user object if available
-    const cached = localStorage.getItem('branchId') || sessionStorage.getItem('branchId');
-    if (cached) {
-      setBranchId(cached);
-      setBranchLoading(false);
-    } else {
-      // Try to infer from attendance summary which contains branchId in context
-      api.get('/attendance/summary')
-        .then(res => {
-          // branchId is resolved server-side from the JWT; we don't get it back directly
-          // We display branch name from the summary if available
-          if (res.data?.branchName) setBranchName(res.data.branchName);
-          setBranchLoading(false);
-        })
-        .catch(() => setBranchLoading(false));
-    }
-  }, []);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      // BACKEND PENDING: POST /medications
-      // This endpoint currently restricts access to Role.PHARMACY only.
-      // The backend team needs to add Role.BRANCH_MANAGER to the @Roles decorator.
-      // The backend service should resolve the branchId from the JWT (same pattern
-      // as it already does for PHARMACY role using findByUserId).
-      // When done, this call will work automatically with no frontend changes needed.
-      await api.post('/medications', {
-        name: form.name,
-        chemicalName: form.chemicalName || undefined,
-        description: form.description || undefined,
-        category: form.category,
-        price: parseFloat(form.price),
-        quantity: parseInt(form.quantity),
-        lowStockThreshold: parseInt(form.lowStockThreshold),
-        requiresPrescription: form.requiresPrescription,
-        branchId: branchId,
-      });
-      toast.success(t('success.medicationAdded'));
-      router.push('/branch/inventory');
-    } catch (err: any) {
-      if (err?.response?.status === 403) {
-        setBackendReady(false);
-        toast.error(t('errors.backendNotEnabled'));
-      } else {
-        toast.error(err.response?.data?.message || t('errors.failedToLoad'));
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const inputCls = "w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm outline-none focus:border-teal-400 transition-colors";
-  const labelCls = "block text-sm font-semibold text-gray-700 mb-1";
+  const inputCls = 'w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm outline-none focus:border-teal-400 transition-colors';
+  const labelCls = 'block text-sm font-semibold text-gray-700 mb-1';
 
   return (
     <div className="space-y-6 max-w-2xl mx-auto">
-
-      <button
-        onClick={() => router.push('/branch/inventory')}
+      <button onClick={() => router.push('/branch/inventory')}
         className="flex items-center gap-2 text-sm font-medium hover:underline"
-        style={{ color: NAVY }}
-      >
+        style={{ color: NAVY }}>
         <ArrowLeftIcon className="w-4 h-4" /> Back to Inventory
       </button>
 
@@ -122,7 +36,7 @@ export default function BranchAddMedicationPage() {
         <p className="mt-1 text-white/70">{t('inventory.addMedicationBranchSubtitle')}</p>
       </div>
 
-      {!backendReady && (
+      {backendPending && (
         <div className="flex items-start gap-3 px-4 py-4 rounded-xl border border-yellow-200 bg-yellow-50">
           <LockClosedIcon className="w-5 h-5 text-yellow-600 shrink-0 mt-0.5" />
           <div>
@@ -139,24 +53,23 @@ export default function BranchAddMedicationPage() {
       )}
 
       <form onSubmit={handleSubmit} className="bg-white rounded-2xl p-6 border border-gray-100 space-y-5">
-
         <div>
-          <label className={labelCls} htmlFor="medicationName">Medication Name <span className="text-red-500">*</span></label>
-          <input id="medicationName" type="text" required value={form.name}
+          <label className={labelCls}>Medication Name <span className="text-red-500">*</span></label>
+          <input type="text" required value={form.name}
             onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
             placeholder="e.g. Amoxicillin 500mg" className={inputCls} />
         </div>
 
         <div>
-          <label className={labelCls} htmlFor="chemicalName">Chemical Name</label>
-          <input id="chemicalName" type="text" value={form.chemicalName}
+          <label className={labelCls}>{t('inventory.chemicalName')}</label>
+          <input type="text" value={form.chemicalName}
             onChange={e => setForm(f => ({ ...f, chemicalName: e.target.value }))}
             placeholder="e.g. Amoxicillin trihydrate" className={inputCls} />
         </div>
 
         <div>
-          <label className={labelCls} htmlFor="category">Category <span className="text-red-500">*</span></label>
-          <select id="category" required value={form.category}
+          <label className={labelCls}>Category <span className="text-red-500">*</span></label>
+          <select required value={form.category}
             onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
             className={inputCls}>
             {FDA_CATEGORIES.map(c => <option key={c} value={c}>{t('medicationCategories.' + c) || c}</option>)}
@@ -165,30 +78,30 @@ export default function BranchAddMedicationPage() {
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className={labelCls} htmlFor="price">Price (RWF) <span className="text-red-500">*</span></label>
-            <input id="price" type="number" required min="0" step="any" value={form.price}
+            <label className={labelCls}>Price (RWF) <span className="text-red-500">*</span></label>
+            <input type="number" required min="0" step="any" value={form.price}
               onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
               placeholder="e.g. 1500" className={inputCls} />
           </div>
           <div>
-            <label className={labelCls} htmlFor="quantity">Quantity (units) <span className="text-red-500">*</span></label>
-            <input id="quantity" type="number" required min="0" value={form.quantity}
+            <label className={labelCls}>Quantity (units) <span className="text-red-500">*</span></label>
+            <input type="number" required min="0" value={form.quantity}
               onChange={e => setForm(f => ({ ...f, quantity: e.target.value }))}
               placeholder="e.g. 100" className={inputCls} />
           </div>
         </div>
 
         <div>
-          <label className={labelCls} htmlFor="lowStockThreshold">{t('inventory.lowStockThresholdUnits')}</label>
-          <input id="lowStockThreshold" type="number" min="1" value={form.lowStockThreshold}
+          <label className={labelCls}>{t('inventory.lowStockThresholdUnits')}</label>
+          <input type="number" min="1" value={form.lowStockThreshold}
             onChange={e => setForm(f => ({ ...f, lowStockThreshold: e.target.value }))}
             className={inputCls} />
           <p className="text-xs text-gray-400 mt-1">{t('inventory.alertRaisedBelow')}</p>
         </div>
 
         <div>
-          <label className={labelCls} htmlFor="description">Description</label>
-          <textarea id="description" rows={3} value={form.description}
+          <label className={labelCls}>{t('inventory.description')}</label>
+          <textarea rows={3} value={form.description}
             onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
             placeholder={t('inventory.searchBranchPlaceholder')}
             className={`${inputCls} resize-none`} />

--- a/src/app/branch/inventory/page.tsx
+++ b/src/app/branch/inventory/page.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
-import api, { unwrapData } from '@/lib/api';
+import api from '@/lib/api';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import toast from 'react-hot-toast';
+import { FDA_CATEGORIES } from '@/lib/constants';
 import {
   MagnifyingGlassIcon,
   PlusIcon,
@@ -17,19 +18,6 @@ import {
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'All Categories',
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
 
 export default function BranchInventoryPage() {
   const { t } = useTranslation();
@@ -55,7 +43,7 @@ export default function BranchInventoryPage() {
       //   GET /medications/pharmacy/out-of-stock → add Role.BRANCH_MANAGER
       // When done, this page will work automatically with no frontend changes needed.
       const res = await api.get('/medications/pharmacy/my-medications');
-      setMedications(unwrapData(res.data));
+      setMedications(Array.isArray(res.data) ? res.data : res.data?.data ?? []);
       setBackendReady(true);
     } catch (err: any) {
       if (err?.response?.status === 403) {
@@ -155,7 +143,6 @@ export default function BranchInventoryPage() {
         <div className="relative w-full sm:w-72">
           <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           <input
-            id="searchInventory"
             type="text"
             placeholder={t('inventory.searchBranchPlaceholder')}
             value={searchTerm}
@@ -275,7 +262,7 @@ export default function BranchInventoryPage() {
           </div>
           <div className="px-4 py-3 border-t border-gray-100 bg-gray-50">
             <p className="text-xs text-gray-500">
-              {t('inventory.showingMedications', { filtered: filtered.length, total: medications.length })}
+              Showing <span className="font-semibold">{filtered.length}</span> of <span className="font-semibold">{medications.length}</span> medications
             </p>
           </div>
         </div>

--- a/src/app/patient/notifications/page.tsx
+++ b/src/app/patient/notifications/page.tsx
@@ -1,5 +1,3 @@
-// frontend/src/app/patient/notifications/page.tsx
-
 'use client';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
@@ -8,9 +6,8 @@ import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
-import { BellIcon, ClipboardDocumentListIcon, ExclamationTriangleIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { POLLING_INTERVAL_MS } from '@/lib/constants';
 
-const POLL_INTERVAL_MS = 30_000; // 30 seconds
 
 type NotificationCategory = 'all' | 'orders' | 'prescriptions' | 'alerts';
 
@@ -21,6 +18,7 @@ interface Notification {
   message: string;
   isRead: boolean;
   orderId?: string;
+  prescriptionId?: string;
   createdAt: string;
 }
 
@@ -30,24 +28,29 @@ const getCategory = (type: string): Omit<NotificationCategory, 'all'> => {
   return 'alerts';
 };
 
-const getIcon = (type: string): string => {
+// Maps notification type → { icon background color, icon emoji, label }
+const getTypeConfig = (type: string) => {
   switch (type) {
-    case 'ORDER_PLACED':           return '🛒';
-    case 'ORDER_ACCEPTED':         return '✅';
-    case 'ORDER_PREPARING':        return '⚗️';
-    case 'ORDER_OUT_FOR_DELIVERY': return '🚚';
-    case 'ORDER_READY_FOR_PICKUP': return '📦';
-    case 'ORDER_DELIVERED':        return '🎉';
-    case 'ORDER_CANCELLED':        return '❌';
-    case 'PRESCRIPTION_APPROVED':  return '📋';
-    case 'PRESCRIPTION_REJECTED':  return '🚫';
-    default:                       return '🔔';
+    case 'ORDER_PLACED':           return { bg: '#EEF2FF', color: '#4F46E5', emoji: '🛒',  label: 'ORDER UPDATE' };
+    case 'ORDER_ACCEPTED':         return { bg: '#ECFDF5', color: '#059669', emoji: '✅',  label: 'ORDER UPDATE' };
+    case 'ORDER_PREPARING':        return { bg: '#FFF7ED', color: '#EA580C', emoji: '⚗️',  label: 'ORDER UPDATE' };
+    case 'ORDER_OUT_FOR_DELIVERY': return { bg: '#EFF6FF', color: '#2563EB', emoji: '🚚',  label: 'ORDER UPDATE' };
+    case 'ORDER_READY_FOR_PICKUP': return { bg: '#F0FAFA', color: '#0D9488', emoji: '📦',  label: 'ORDER UPDATE' };
+    case 'ORDER_DELIVERED':        return { bg: '#ECFDF5', color: '#16A34A', emoji: '🎉',  label: 'ORDER UPDATE' };
+    case 'ORDER_CANCELLED':        return { bg: '#FEF2F2', color: '#DC2626', emoji: '❌',  label: 'ORDER UPDATE' };
+    case 'PRESCRIPTION_APPROVED':  return { bg: '#FFF7ED', color: '#EA580C', emoji: '📋',  label: 'PRESCRIPTION' };
+    case 'PRESCRIPTION_REJECTED':  return { bg: '#FEF2F2', color: '#DC2626', emoji: '🚫',  label: 'PRESCRIPTION' };
+    default:                       return { bg: '#F3F4F6', color: '#6B7280', emoji: '🔔',  label: 'ALERT' };
   }
 };
+
+const NAVY = '#1E3A5F';
+const TEAL = '#2D9B8A';
 
 export default function PatientNotificationsPage() {
   const { t } = useTranslation();
   const router = useRouter();
+
   const [notifications, setNotifications]   = useState<Notification[]>([]);
   const [loading, setLoading]               = useState(true);
   const [refreshing, setRefreshing]         = useState(false);
@@ -55,50 +58,35 @@ export default function PatientNotificationsPage() {
   const [activeCategory, setActiveCategory] = useState<NotificationCategory>('all');
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // ─── Fetch (used both on mount and by the interval) ───────────────────────
   const fetchNotifications = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
     else         setRefreshing(true);
     try {
       const res = await api.get('/notifications?userType=patient');
-      setNotifications(res.data);
+      setNotifications(Array.isArray(res.data) ? res.data : res.data?.data ?? []);
       setLastUpdated(new Date());
-    } catch (error) {
-      console.error('Failed to fetch notifications:', error);
+    } catch (err) {
+      console.error('Failed to fetch notifications:', err);
     } finally {
       setLoading(false);
       setRefreshing(false);
     }
   }, []);
 
-  // ─── Mount: initial fetch + start polling; unmount: clear interval ────────
   useEffect(() => {
     fetchNotifications(false);
-
-    intervalRef.current = setInterval(() => {
-      fetchNotifications(true); // silent = won't show spinner, just background refresh
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
+    intervalRef.current = setInterval(() => fetchNotifications(true), POLLING_INTERVAL_MS);
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
   }, [fetchNotifications]);
 
-  // ─── Actions ──────────────────────────────────────────────────────────────
-  const handleMarkAsRead = async (notification: Notification) => {
-    if (!notification.isRead) {
+  const handleMarkAsRead = async (n: Notification) => {
+    if (!n.isRead) {
       try {
-        await api.put(`/notifications/${notification.id}/read`);
-        setNotifications(prev =>
-          prev.map(n => n.id === notification.id ? { ...n, isRead: true } : n)
-        );
-      } catch (error) {
-        console.error('Failed to mark as read:', error);
-      }
+        await api.put(`/notifications/${n.id}/read`);
+        setNotifications(prev => prev.map(x => x.id === n.id ? { ...x, isRead: true } : x));
+      } catch { /* silent */ }
     }
-    if (notification.orderId) {
-      router.push(`/patient/orders/${notification.orderId}`);
-    }
+    if (n.orderId) router.push(`/patient/orders/${n.orderId}`);
   };
 
   const handleMarkAllAsRead = async () => {
@@ -111,148 +99,242 @@ export default function PatientNotificationsPage() {
     }
   };
 
-  // ─── Derived state ────────────────────────────────────────────────────────
+  const handleDelete = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    try {
+      await api.delete(`/notifications/${id}`);
+      setNotifications(prev => prev.filter(n => n.id !== id));
+    } catch {
+      // optimistic: remove anyway for UX
+      setNotifications(prev => prev.filter(n => n.id !== id));
+    }
+  };
+
   const filteredNotifications = activeCategory === 'all'
     ? notifications
     : notifications.filter(n => getCategory(n.type) === activeCategory);
 
   const unreadCount = notifications.filter(n => !n.isRead).length;
+
   const getCategoryCount = (cat: NotificationCategory) =>
-    cat === 'all' ? notifications.length : notifications.filter(n => getCategory(n.type) === cat).length;
+    cat === 'all'
+      ? notifications.length
+      : notifications.filter(n => getCategory(n.type) === cat).length;
 
   const formatTime = (dateStr: string) => {
     const diffMs    = Date.now() - new Date(dateStr).getTime();
     const diffMins  = Math.floor(diffMs / 60_000);
     const diffHours = Math.floor(diffMins / 60);
-    const diffDays = Math.floor(diffHours / 24);
-    if (diffMins < 1) return t('common.justNow');
-    if (diffMins < 60) return `${diffMins} ${t('notifications2.minAgo')}`;
+    const diffDays  = Math.floor(diffHours / 24);
+    if (diffMins < 1)   return t('common.justNow');
+    if (diffMins < 60)  return `${diffMins} ${t('notifications2.minAgo')}`;
     if (diffHours < 24) return `${diffHours} ${diffHours > 1 ? t('notifications2.hoursAgo') : t('notifications2.hourAgo')}`;
     return `${diffDays} ${diffDays > 1 ? t('notifications2.daysAgo') : t('notifications2.dayAgo')}`;
   };
 
   if (loading) return <div className="flex justify-center py-20"><LoadingSpinner /></div>;
 
+  const TABS: { id: NotificationCategory; label: string }[] = [
+    { id: 'all',           label: `All (${getCategoryCount('all')})` },
+    { id: 'orders',        label: `Orders (${getCategoryCount('orders')})` },
+    { id: 'prescriptions', label: `Prescriptions (${getCategoryCount('prescriptions')})` },
+    { id: 'alerts',        label: `Alerts (${getCategoryCount('alerts')})` },
+  ];
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-8">
-        <div className="flex items-center justify-between mb-2">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-1">
+    <div className="min-h-screen bg-gray-50 p-4 lg:p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+
+        {/* ── Header card ──────────────────────────────────────────────── */}
+        <div className="bg-white rounded-2xl p-6 shadow-sm">
+          <div className="flex items-start justify-between mb-1">
+            <h1 className="text-3xl font-bold" style={{ color: NAVY }}>
               {t('notifications2.notifications')}
             </h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              {unreadCount > 0
-                ? `${unreadCount} ${unreadCount !== 1 ? t('notifications2.unreadNotifications') : t('notifications2.unreadNotification')}`
-                : t('notifications2.allCaughtUp')}
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            {/* Live refresh indicator */}
-            <div className="flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
-              <ArrowPathIcon className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin text-teal-500' : ''}`} />
-              <span>
-                {refreshing
-                  ? t('notifications2.refreshing')
-                  : lastUpdated
-                    ? `${t('notifications2.updated')} ${formatTime(lastUpdated.toISOString())}`
-                    : ''}
-              </span>
-            </div>
-            {unreadCount > 0 && (
-              <button
-                onClick={handleMarkAllAsRead}
-                className="text-[#1E4D8C] dark:text-blue-400 hover:underline font-medium text-sm"
-              >
-                {t('notifications2.markAllAsRead')}
-              </button>
-            )}
-          </div>
-        </div>
-
-        {/* Category Tabs */}
-        <div className="flex flex-wrap gap-3 mt-6">
-          {([
-            { id: 'all',           label: t('notifications2.all'),            icon: BellIcon },
-            { id: 'orders',        label: t('common.orders'), icon: ClipboardDocumentListIcon },
-            { id: 'prescriptions', label: t('prescriptions.prescriptionsTitle'), icon: ClipboardDocumentListIcon },
-            { id: 'alerts',        label: t('notifications2.alerts'), icon: ExclamationTriangleIcon },
-          ] as const).map(({ id, label, icon: Icon }) => (
-            <button key={id} onClick={() => setActiveCategory(id)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-xl font-medium transition-all ${
-                activeCategory === id
-                  ? 'bg-[#1E4D8C] text-white shadow-lg'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-              }`}>
-              <Icon className="w-5 h-5" />
-              {label} ({getCategoryCount(id)})
+            <button
+              onClick={handleMarkAllAsRead}
+              className="flex items-center gap-2 px-4 py-2 rounded-xl border text-sm font-medium transition-colors hover:bg-gray-50"
+              style={{ borderColor: NAVY, color: NAVY }}
+            >
+              {/* checkmark icon */}
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              {t('notifications2.markAllAsRead')}
             </button>
-          ))}
-        </div>
-      </div>
+          </div>
 
-      {/* Notifications List */}
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg overflow-hidden">
-      <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">
-          {activeCategory === 'all'
-            ? t('notifications2.allNotifications')
-            : activeCategory === 'orders'
-            ? t('notifications2.ordersNotifications')
-            : activeCategory === 'prescriptions'
-            ? t('notifications2.prescriptionsNotifications')
-            : t('notifications2.alertsNotifications')}
-          </h2>
+          {unreadCount > 0 && (
+            <p className="text-sm font-medium mb-5" style={{ color: TEAL }}>
+              {t('notifications2.youHave')} {unreadCount} {unreadCount === 1
+                ? t('notifications2.unreadNotification')
+                : t('notifications2.unreadNotifications')}
+            </p>
+          )}
+
+          {/* Tabs */}
+          <div className="flex flex-wrap gap-2">
+            {TABS.map(tab => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveCategory(tab.id)}
+                className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold transition-all"
+                style={
+                  activeCategory === tab.id
+                    ? { backgroundColor: NAVY, color: '#fff' }
+                    : { backgroundColor: '#F3F4F6', color: '#374151' }
+                }
+              >
+                {/* tab icon */}
+                {tab.id === 'all'           && <span>🔔</span>}
+                {tab.id === 'orders'        && <span>🛒</span>}
+                {tab.id === 'prescriptions' && <span>📋</span>}
+                {tab.id === 'alerts'        && <span>⚠️</span>}
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Refresh indicator */}
+          {refreshing && (
+            <p className="text-xs text-gray-400 mt-3 flex items-center gap-1">
+              <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+              {t('notifications2.refreshing')}
+            </p>
+          )}
         </div>
 
+        {/* ── Notification section header ───────────────────────────────── */}
+        <h2 className="text-xl font-bold px-1" style={{ color: NAVY }}>
+          {activeCategory === 'all'           ? t('notifications2.allNotifications')
+          : activeCategory === 'orders'        ? t('notifications2.ordersNotifications')
+          : activeCategory === 'prescriptions' ? t('notifications2.prescriptionsNotifications')
+          :                                      t('notifications2.alertsNotifications')}
+        </h2>
+
+        {/* ── Notification cards ────────────────────────────────────────── */}
         {filteredNotifications.length === 0 ? (
-          <div className="p-12 text-center">
-            <p className="text-6xl mb-4">🔔</p>
-            <p className="text-gray-500 dark:text-gray-400 text-lg">
+          <div className="bg-white rounded-2xl p-16 text-center shadow-sm">
+            <p className="text-5xl mb-4">🔔</p>
+            <p className="text-gray-400 font-medium">
               {notifications.length === 0
                 ? t('notifications2.noNotificationsYet')
                 : t('notifications2.noNotificationsInCategory')}
             </p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-200 dark:divide-gray-700">
-            {filteredNotifications.map(notification => (
-              <div
-                key={notification.id}
-                onClick={() => handleMarkAsRead(notification)}
-                className={`p-6 hover:bg-[#1E4D8C]/5 dark:hover:bg-gray-700 transition-all cursor-pointer ${
-                  !notification.isRead
-                    ? 'bg-[#2D9B8A]/5 border-l-4 border-[#2D9B8A]'
-                    : 'border-l-4 border-transparent'
-                }`}
-              >
-                <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 bg-[#1E4D8C]/10 dark:bg-[#1E4D8C]/30 rounded-xl flex items-center justify-center shrink-0">
-                    <span className="text-2xl">{getIcon(notification.type)}</span>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1">
-                        <h3 className="font-bold text-gray-800 dark:text-gray-100 mb-1">{notification.title}</h3>
-                        <p className="text-sm text-gray-600 dark:text-gray-400">{notification.message}</p>
-                      </div>
-                      {!notification.isRead && (
-                        <span className="px-3 py-1 bg-[#2D9B8A] text-white text-xs font-semibold rounded-full shrink-0">
-                        {t('notifications2.new')}
-                        </span>
-                      )}
+          <div className="space-y-4">
+            {filteredNotifications.map(n => {
+              const cfg = getTypeConfig(n.type);
+              const isOrder        = n.type.startsWith('ORDER_');
+              const isOutForDelivery = n.type === 'ORDER_OUT_FOR_DELIVERY';
+              const isPrescription = n.type.startsWith('PRESCRIPTION_');
+
+              return (
+                <div
+                  key={n.id}
+                  onClick={() => handleMarkAsRead(n)}
+                  className="bg-white rounded-2xl p-5 shadow-sm cursor-pointer transition-shadow hover:shadow-md relative"
+                >
+                  {/* Unread blue dot */}
+                  {!n.isRead && (
+                    <span
+                      className="absolute top-5 right-12 w-2.5 h-2.5 rounded-full"
+                      style={{ backgroundColor: '#3B82F6' }}
+                    />
+                  )}
+
+                  {/* Delete / more button */}
+                  <button
+                    onClick={e => handleDelete(e, n.id)}
+                    className="absolute top-4 right-4 p-1 text-gray-300 hover:text-gray-500 transition-colors"
+                    title="Delete notification"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+
+                  <div className="flex gap-4">
+                    {/* Icon badge */}
+                    <div
+                      className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 text-xl"
+                      style={{ backgroundColor: cfg.bg }}
+                    >
+                      {cfg.emoji}
                     </div>
-                  <div className="flex items-center gap-3 mt-2">
-                    <p className="text-xs text-gray-500 dark:text-gray-500">{formatTime(notification.createdAt)}</p>
-                    {notification.orderId && (
-                        <span className="text-xs text-[#1E4D8C] dark:text-blue-400 font-medium">{t('notifications2.viewOrder')}</span>
-                    )}
+
+                    <div className="flex-1 min-w-0 pr-6">
+                      {/* Type label + timestamp */}
+                      <div className="flex items-center gap-2 mb-1">
+                        <span
+                          className="text-xs font-bold tracking-wide"
+                          style={{ color: cfg.color }}
+                        >
+                          {cfg.label}
+                        </span>
+                        <span className="text-gray-300 text-xs">•</span>
+                        <span className="text-xs text-gray-400">{formatTime(n.createdAt)}</span>
+                      </div>
+
+                      {/* Title */}
+                      <h3 className="font-bold text-gray-900 mb-1 leading-snug">
+                        {n.title}
+                      </h3>
+
+                      {/* Message — bold drug names if present */}
+                      <p className="text-sm text-gray-500 leading-relaxed mb-3">
+                        {n.message}
+                      </p>
+
+                      {/* Action buttons */}
+                      <div className="flex flex-wrap gap-2">
+                        {isOutForDelivery && (
+                          <button
+                            onClick={e => { e.stopPropagation(); if (n.orderId) router.push(`/patient/orders/${n.orderId}`); }}
+                            className="px-4 py-1.5 rounded-lg text-xs font-semibold text-white transition-opacity hover:opacity-90"
+                            style={{ backgroundColor: NAVY }}
+                          >
+                            Track Courier
+                          </button>
+                        )}
+                        {isOrder && n.orderId && (
+                          <button
+                            onClick={e => { e.stopPropagation(); router.push(`/patient/orders/${n.orderId}`); }}
+                            className="px-4 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-gray-50"
+                            style={{ borderColor: '#D1D5DB', color: '#374151' }}
+                          >
+                            View Order
+                          </button>
+                        )}
+                        {isPrescription && n.prescriptionId && (
+                          <button
+                            onClick={e => { e.stopPropagation(); router.push(`/patient/prescriptions/${n.prescriptionId}`); }}
+                            className="px-4 py-1.5 rounded-lg text-xs font-semibold text-white transition-opacity hover:opacity-90"
+                            style={{ backgroundColor: NAVY }}
+                          >
+                            View Prescription
+                          </button>
+                        )}
+                        {isPrescription && (
+                          <button
+                            onClick={e => { e.stopPropagation(); router.push('/patient/search'); }}
+                            className="px-4 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-gray-50"
+                            style={{ borderColor: '#D1D5DB', color: '#374151' }}
+                          >
+                            Find Pharmacy
+                          </button>
+                        )}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@/components/shared/LanguageSwitcher';
+import { SUPPORT_EMAIL } from '@/lib/constants';
 
 export default function PendingApprovalPage() {
   const { t } = useTranslation();
@@ -118,7 +119,7 @@ export default function PendingApprovalPage() {
           {t('pending.contactInfo')}
           </p>
         <p className="text-sm text-gray-500 dark:text-gray-500 mt-2">
-          {t('pending.email')}: <span className="text-purple-600 dark:text-purple-400 font-medium">support@evuze.com</span>
+          {t('pending.email')}: <span className="text-purple-600 dark:text-purple-400 font-medium">{SUPPORT_EMAIL}</span>
         </p>
       </div>
     </div>

--- a/src/app/pharmacy-rejected/page.tsx
+++ b/src/app/pharmacy-rejected/page.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import api from '@/lib/api';
 import toast from 'react-hot-toast';
 import LanguageSwitcher from '@/components/shared/LanguageSwitcher';
+import { SUPPORT_EMAIL } from '@/lib/constants';
 
 export default function PharmacyRejectedPage() {
   const { t } = useTranslation();
@@ -301,7 +302,7 @@ export default function PharmacyRejectedPage() {
           Need help? Contact our support team
           </p>
         <p className="text-sm text-gray-500 dark:text-gray-500 mt-2">
-          Email: <span className="text-orange-600 dark:text-orange-400 font-medium">support@evuze.com</span>
+          Email: <span className="text-orange-600 dark:text-orange-400 font-medium">{SUPPORT_EMAIL}</span>
         </p>
       </div>
     </div>

--- a/src/app/pharmacy/inventory/[id]/page.tsx
+++ b/src/app/pharmacy/inventory/[id]/page.tsx
@@ -11,17 +11,8 @@ import PharmacyTopbar from '@/components/pharmacy/PharmacyTopbar';
 import PharmacySidebar from '@/components/pharmacy/PharmacySidebar';
 import SupportBot from '@/components/pharmacy/SupportBot';
 import { ArrowLeftIcon, PencilIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics','Antibiotics & Antimicrobials','Antifungals','Antivirals & Antiretrovirals',
-  'Antimalaria','Antituberculosis','Antiparasitics & Anthelmintics','Cardiovascular & Antihypertensives',
-  'Antidiabetics','Gastrointestinal','Respiratory & Bronchodilators','Central Nervous System',
-  'Vitamins, Minerals & Supplements','Dermatologicals','Ophthalmologicals','ENT (Ear, Nose & Throat)',
-  'Hormones & Endocrine','Vaccines & Biologicals','Oncologicals','Immunosuppressants',
-  'Contraceptives','Haematologicals','Musculoskeletal & Anti-inflammatories','Urological',
-  'Psychiatric & Psychotropic','Anesthetics','Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines','Other',
-];
 
 export default function EditMedicationPage() {
   const { t } = useTranslation();
@@ -73,19 +64,19 @@ export default function EditMedicationPage() {
       setEditing(false);
       fetchMedication();
     } catch (err: any) {
-      toast.error(err.response?.data?.message || t('common.updateFailed'));
+      toast.error(err.response?.data?.message || 'Update failed');
     } finally { setSaving(false); }
   };
 
   const handleDelete = async () => {
-    if (!confirm(t('inventory.confirmRemove', { name: med?.name }))) return;
+    if (!confirm(`Are you sure you want to remove "${med?.name}" from inventory?`)) return;
     setDeleting(true);
     try {
       await api.delete(`/medications/${params.id}`);
       toast.success(t('success.medicationRemoved'));
       router.push('/pharmacy/inventory');
     } catch (err: any) {
-      toast.error(err.response?.data?.message || t('common.deleteFailed'));
+      toast.error(err.response?.data?.message || 'Delete failed');
     } finally { setDeleting(false); }
   };
 
@@ -115,7 +106,7 @@ export default function EditMedicationPage() {
         <div className="max-w-3xl mx-auto space-y-6">
 
           <button onClick={() => router.back()} className="flex items-center gap-2 text-gray-600 hover:text-gray-900 text-sm">
-            <ArrowLeftIcon className="w-4 h-4" /> {t('inventory.backToInventory')}
+            <ArrowLeftIcon className="w-4 h-4" /> Back to Inventory
             </button>
 
           {/* Header card */}
@@ -129,7 +120,7 @@ export default function EditMedicationPage() {
                 stockStatus === 'low' ? 'bg-yellow-400 text-yellow-900' :
                 'bg-green-400 text-green-900'
               }`}>
-              {stockStatus === 'out' ? t('inventory.outOfStock') : stockStatus === 'low' ? t('inventory.lowStock') : t('inventory.inStock')}
+              {stockStatus === 'out' ? 'Out of Stock' : stockStatus === 'low' ? 'Low Stock' : 'In Stock'}
               </span>
           </div>
 
@@ -139,22 +130,22 @@ export default function EditMedicationPage() {
                 <>
                 <button onClick={() => setEditing(true)}
                     className="flex items-center gap-2 px-5 py-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium">
-                  <PencilIcon className="w-4 h-4" /> {t('pharmacy.editMedication')}
+                  <PencilIcon className="w-4 h-4" /> Edit Medication
                   </button>
                 <button onClick={handleDelete} disabled={deleting}
                     className="flex items-center gap-2 px-5 py-2.5 bg-red-500 hover:bg-red-600 text-white rounded-lg text-sm font-medium disabled:opacity-50">
-                  <TrashIcon className="w-4 h-4" /> {deleting ? t('inventory.removing') : t('inventory.remove')}
+                  <TrashIcon className="w-4 h-4" /> {deleting ? 'Removing...' : 'Remove'}
                   </button>
               </>
             ) : (
                 <>
                 <button onClick={handleSave} disabled={saving}
                     className="flex items-center gap-2 px-5 py-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium disabled:opacity-50">
-                  <CheckIcon className="w-4 h-4" /> {saving ? t('common.saving') : t('common.saveChanges')}
+                  <CheckIcon className="w-4 h-4" /> {saving ? 'Saving...' : 'Save Changes'}
                   </button>
                 <button onClick={() => { setEditing(false); fetchMedication(); }}
                     className="flex items-center gap-2 px-5 py-2.5 border-2 border-gray-300 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50">
-                  <XMarkIcon className="w-4 h-4" /> {t('common.cancel')}
+                  <XMarkIcon className="w-4 h-4" /> Cancel
                   </button>
               </>
             )}
@@ -229,7 +220,7 @@ export default function EditMedicationPage() {
                   ? <input type="checkbox" checked={form.requiresPrescription} onChange={e => setForm({...form, requiresPrescription: e.target.checked})} className="w-4 h-4 text-teal-500 rounded" />
                 : <span>{form.requiresPrescription ? '' : ''}</span>}
                 <span className="text-sm font-medium text-gray-700">
-                {form.requiresPrescription ? t('inventory.requiresPrescription') : t('inventory.noPrescriptionRequired')}
+                {form.requiresPrescription ? 'Requires Prescription' : 'No Prescription Required'}
                 </span>
             </div>
           </div>

--- a/src/app/pharmacy/inventory/[id]/page.tsx
+++ b/src/app/pharmacy/inventory/[id]/page.tsx
@@ -9,7 +9,7 @@ import toast from 'react-hot-toast';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import PharmacyTopbar from '@/components/pharmacy/PharmacyTopbar';
 import PharmacySidebar from '@/components/pharmacy/PharmacySidebar';
-import SupportBot from '@/components/pharmacy/SupportBot';
+import SupportBot from '@/components/shared/SupportBot';
 import { ArrowLeftIcon, PencilIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { FDA_CATEGORIES } from '@/lib/constants';
 

--- a/src/app/pharmacy/inventory/add/page.tsx
+++ b/src/app/pharmacy/inventory/add/page.tsx
@@ -1,222 +1,165 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
-import api, { unwrapData } from '@/lib/api';
-import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 import { ArrowLeftIcon, PlusIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
-
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
+import { useState } from 'react';
+import { useMedicationForm } from '@/hooks/useMedicationForm';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
 type Mode = 'manual' | 'upload';
 
 export default function AddMedicationPage() {
-  const { t } = useTranslation();
-  const router = useRouter();
+  const { t }    = useTranslation();
+  const router   = useRouter();
   const [mode, setMode] = useState<Mode>('manual');
-  const [loading, setLoading] = useState(false);
-  const [branches, setBranches] = useState<any[]>([]);
-  const [branchesLoading, setBranchesLoading] = useState(true);
 
-  const [form, setForm] = useState({
-    name: '',
-    branchId: '',
-    category: FDA_CATEGORIES[0],
-    chemicalName: '',
-    description: '',
-    price: '',           // correct DTO field name
-    quantity: '',        // correct DTO field name
-    lowStockThreshold: '10',
-    requiresPrescription: false,
-  });
+  const {
+    form, setForm,
+    loading,
+    contextLoading: branchesLoading,
+    branches,
+    handleSubmit,
+  } = useMedicationForm('pharmacy');
 
-  useEffect(() => {
-    api.get('/branches/my-branches')
-      .then(res => {
-        const list = unwrapData<any>(res.data);
-        setBranches(list);
-        if (list.length === 1) setForm(f => ({ ...f, branchId: list[0].id }));
-      })
-      .catch(() => toast.error(t('errors.failedToLoadBranches')))
-      .finally(() => setBranchesLoading(false));
-  }, []);
-
-  const handleManualSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!form.branchId) { toast.error(t('form.selectBranch')); return; }
-    setLoading(true);
-    try {
-      await api.post('/medications', {
-        branchId: form.branchId,
-        name: form.name,
-        chemicalName: form.chemicalName || undefined,
-        description: form.description || undefined,
-        category: form.category,
-        price: parseFloat(form.price),           // correct field name
-        quantity: parseInt(form.quantity),        // correct field name
-        lowStockThreshold: parseInt(form.lowStockThreshold),
-        requiresPrescription: form.requiresPrescription,
-      });
-      toast.success(t('success.medicationAdded'));
-      router.push('/pharmacy/inventory');
-    } catch (err: any) {
-      toast.error(err.response?.data?.message || t('inventory.failedToAdd'));
-    } finally { setLoading(false); }
-  };
-
-  const inputCls = "w-full px-3 py-2.5 border-2 border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500 outline-none text-sm";
-  const labelCls = "block text-sm font-semibold text-gray-700 mb-1";
+  const inputCls = 'w-full px-3 py-2.5 border-2 border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500 outline-none text-sm';
+  const labelCls = 'block text-sm font-semibold text-gray-700 mb-1';
 
   return (
     <div className="space-y-6">
-    <div className="flex items-center gap-4">
-      <button onClick={() => router.back()} className="flex items-center gap-2 text-gray-600 hover:text-gray-900 text-sm">
-        <ArrowLeftIcon className="w-5 h-5" /> {t('common.back')}
+      <div className="flex items-center gap-4">
+        <button onClick={() => router.back()} className="flex items-center gap-2 text-gray-600 hover:text-gray-900 text-sm">
+          <ArrowLeftIcon className="w-5 h-5" /> Back
         </button>
-    </div>
+      </div>
 
-    <div className="bg-linear-to-r from-[#1E4D8C] via-[#2563a8] to-[#1a3d6f] rounded-2xl p-6 text-white">
-      <h1 className="text-2xl font-bold mb-1">{t('pharmacy.addMedication')}</h1>
-      <p className="text-blue-100 text-sm">{t('inventory.addMedicationSubtitle')}</p>
-    </div>
+      <div className="bg-linear-to-r from-[#1E4D8C] via-[#2563a8] to-[#1a3d6f] rounded-2xl p-6 text-white">
+        <h1 className="text-2xl font-bold mb-1">{t('pharmacy.addMedication')}</h1>
+        <p className="text-blue-100 text-sm">{t('inventory.addMedicationSubtitle')}</p>
+      </div>
 
-    {/* Mode switcher */}
+      {/* Mode switcher */}
       <div className="flex bg-white rounded-xl shadow-sm border border-gray-200 p-1 w-fit">
-      <button onClick={() => setMode('manual')}
+        <button onClick={() => setMode('manual')}
           className={`flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold transition-all ${mode === 'manual' ? 'bg-teal-500 text-white shadow' : 'text-gray-600 hover:text-gray-900'}`}>
-        <PlusIcon className="w-4 h-4" /> {t('inventory.addManually')}
+          <PlusIcon className="w-4 h-4" /> Add Manually
         </button>
-      <button onClick={() => setMode('upload')}
+        <button onClick={() => setMode('upload')}
           className={`flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold transition-all ${mode === 'upload' ? 'bg-teal-500 text-white shadow' : 'text-gray-600 hover:text-gray-900'}`}>
-        <ArrowUpTrayIcon className="w-4 h-4" /> {t('inventory.uploadFile')}
+          <ArrowUpTrayIcon className="w-4 h-4" /> Upload File
         </button>
-    </div>
+      </div>
 
-    {/* Manual form */}
+      {/* Manual form */}
       {mode === 'manual' && (
-        <form onSubmit={handleManualSubmit} className="bg-white rounded-xl shadow-md p-6 space-y-5">
-        <h2 className="text-lg font-bold text-gray-900 border-b pb-3">{t('inventory.medicationInfo')}</h2>
+        <form onSubmit={handleSubmit} className="bg-white rounded-xl shadow-md p-6 space-y-5">
+          <h2 className="text-lg font-bold text-gray-900 border-b pb-3">{t('inventory.medicationInfo')}</h2>
 
-        {/* Branch selector — required */}
+          {/* Branch selector */}
           <div>
-          <label className={labelCls}>{t('inventory.branchLabel')} <span className="text-red-500">*</span></label>
-          {branchesLoading ? (
+            <label className={labelCls}>Branch <span className="text-red-500">*</span></label>
+            {branchesLoading ? (
               <div className="h-10 bg-gray-100 rounded-lg animate-pulse" />
-          ) : (
-              <select
-                required
-                value={form.branchId}
-                onChange={e => setForm({ ...form, branchId: e.target.value })}
-                className={inputCls}
-              >
-              <option value="">{t('inventory.selectBranch')}</option>
-              {branches.map((b: any) => (
-                  <option key={b.id} value={b.id}>{b.name}</option>
-              ))}
-              </select>
-          )}
-            <p className="text-xs text-gray-500 mt-1">{t('inventory.medicationAddedToBranch')}</p>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label className={labelCls}>{t('inventory.medicationNameLabel')} <span className="text-red-500">*</span></label>
-            <input type="text" required value={form.name}
-                onChange={e => setForm({ ...form, name: e.target.value })}
-                className={inputCls} placeholder="e.g. Paracetamol 500mg" />
-          </div>
-          <div>
-            <label className={labelCls}>{t('inventory.genericName')}</label>
-            <input type="text" value={form.chemicalName}
-                onChange={e => setForm({ ...form, chemicalName: e.target.value })}
-                className={inputCls} placeholder="e.g. Acetaminophen" />
-          </div>
-          <div>
-            <label className={labelCls}>{t('pharmacy.category')} <span className="text-red-500">*</span></label>
-            <select required value={form.category}
-                onChange={e => setForm({ ...form, category: e.target.value })}
+            ) : (
+              <select required value={form.branchId}
+                onChange={e => setForm(f => ({ ...f, branchId: e.target.value }))}
                 className={inputCls}>
-              {FDA_CATEGORIES.map(cat => <option key={cat} value={cat}>{cat}</option>)}
+                <option value="">{t('inventory.selectBranch')}</option>
+                {branches.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
               </select>
-            <p className="text-xs text-gray-500 mt-1">{t('inventory.rwandaFdaCategories')}</p>
+            )}
+            <p className="text-xs text-gray-500 mt-1">{t('inventory.medicationAddedToBranch')}</p>
           </div>
-          <div>
-            <label className={labelCls}>{t('inventory.unitPriceRwf')} <span className="text-red-500">*</span></label>
-            <input type="number" required min="0" step="0.01" value={form.price}
-                onChange={e => setForm({ ...form, price: e.target.value })}
-                className={inputCls} placeholder="e.g. 500" />
-          </div>
-          <div>
-            <label className={labelCls}>{t('inventory.quantityInStock')} <span className="text-red-500">*</span></label>
-            <input type="number" required min="0" value={form.quantity}
-                onChange={e => setForm({ ...form, quantity: e.target.value })}
-                className={inputCls} placeholder="e.g. 100" />
-          </div>
-          <div>
-            <label className={labelCls}>{t('inventory.lowStockThresholdUnits')}</label>
-            <input type="number" min="1" value={form.lowStockThreshold}
-                onChange={e => setForm({ ...form, lowStockThreshold: e.target.value })}
-                className={inputCls} placeholder="e.g. 10" />
-            <p className="text-xs text-gray-500 mt-1">{t('inventory.alertWhenBelow')}</p>
-          </div>
-        </div>
 
-        <div>
-          <label className={labelCls}>{t('inventory.description')}</label>
-          <textarea value={form.description}
-              onChange={e => setForm({ ...form, description: e.target.value })}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className={labelCls}>Medication Name <span className="text-red-500">*</span></label>
+              <input type="text" required value={form.name}
+                onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                className={inputCls} placeholder="e.g. Paracetamol 500mg" />
+            </div>
+            <div>
+              <label className={labelCls}>{t('inventory.genericName')}</label>
+              <input type="text" value={form.chemicalName}
+                onChange={e => setForm(f => ({ ...f, chemicalName: e.target.value }))}
+                className={inputCls} placeholder="e.g. Acetaminophen" />
+            </div>
+            <div>
+              <label className={labelCls}>Category <span className="text-red-500">*</span></label>
+              <select required value={form.category}
+                onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
+                className={inputCls}>
+                {FDA_CATEGORIES.map(cat => <option key={cat} value={cat}>{cat}</option>)}
+              </select>
+              <p className="text-xs text-gray-500 mt-1">{t('inventory.rwandaFdaCategories')}</p>
+            </div>
+            <div>
+              <label className={labelCls}>Unit Price (RWF) <span className="text-red-500">*</span></label>
+              <input type="number" required min="0" step="0.01" value={form.price}
+                onChange={e => setForm(f => ({ ...f, price: e.target.value }))}
+                className={inputCls} placeholder="e.g. 500" />
+            </div>
+            <div>
+              <label className={labelCls}>Quantity In Stock <span className="text-red-500">*</span></label>
+              <input type="number" required min="0" value={form.quantity}
+                onChange={e => setForm(f => ({ ...f, quantity: e.target.value }))}
+                className={inputCls} placeholder="e.g. 100" />
+            </div>
+            <div>
+              <label className={labelCls}>{t('inventory.lowStockThresholdUnits')}</label>
+              <input type="number" min="1" value={form.lowStockThreshold}
+                onChange={e => setForm(f => ({ ...f, lowStockThreshold: e.target.value }))}
+                className={inputCls} placeholder="e.g. 10" />
+              <p className="text-xs text-gray-500 mt-1">{t('inventory.alertWhenBelow')}</p>
+            </div>
+          </div>
+
+          <div>
+            <label className={labelCls}>{t('inventory.description')}</label>
+            <textarea value={form.description}
+              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
               className={`${inputCls} resize-none`} rows={3}
               placeholder={t('inventory.searchPlaceholder')} />
-        </div>
+          </div>
 
-        <div className="flex items-center gap-3 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <input type="checkbox" id="prescription" checked={form.requiresPrescription}
-              onChange={e => setForm({ ...form, requiresPrescription: e.target.checked })}
+          <div className="flex items-center gap-3 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <input type="checkbox" id="prescription" checked={form.requiresPrescription}
+              onChange={e => setForm(f => ({ ...f, requiresPrescription: e.target.checked }))}
               className="w-4 h-4 text-teal-500 rounded" />
-          <label htmlFor="prescription" className="text-sm font-medium text-gray-700">
-            {t('inventory.requiresPrescriptionLabel')}
+            <label htmlFor="prescription" className="text-sm font-medium text-gray-700">
+              Requires Prescription — this medication will only be dispensed with a valid prescription
             </label>
-        </div>
+          </div>
 
-        <div className="flex justify-end gap-3 pt-2">
-          <button type="button" onClick={() => router.back()}
+          <div className="flex justify-end gap-3 pt-2">
+            <button type="button" onClick={() => router.back()}
               className="px-6 py-2.5 border-2 border-gray-300 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-50">
-            {t('common.cancel')}
+              Cancel
             </button>
-          <button type="submit" disabled={loading}
+            <button type="submit" disabled={loading}
               className="px-6 py-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg font-medium text-sm disabled:opacity-50 flex items-center gap-2">
-            {loading ? <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" /> {t('common.saving')}</> : t('pharmacy.addMedication')}
+              {loading
+                ? <><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" /> Saving...</>
+                : 'Add Medication'}
             </button>
-        </div>
-      </form>
-    )}
+          </div>
+        </form>
+      )}
 
-      {/* Upload mode — bulk upload endpoint doesn't exist on backend, show info */}
+      {/* Upload mode */}
       {mode === 'upload' && (
         <div className="bg-white rounded-xl shadow-md p-6 space-y-5">
-        <h2 className="text-lg font-bold text-gray-900 border-b pb-3">{t('inventory.bulkUpload')}</h2>
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-5 text-sm text-amber-800">
-          <p className="font-semibold mb-1">{t('inventory.bulkUploadNotAvailable')}</p>
-          <p className="text-amber-700">{t('inventory.bulkUploadDesc')}</p>
-        </div>
-        <button onClick={() => setMode('manual')}
+          <h2 className="text-lg font-bold text-gray-900 border-b pb-3">{t('inventory.bulkUpload')}</h2>
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-5 text-sm text-amber-800">
+            <p className="font-semibold mb-1">{t('inventory.bulkUploadNotAvailable')}</p>
+            <p className="text-amber-700">{t('inventory.bulkUploadDesc')}</p>
+          </div>
+          <button onClick={() => setMode('manual')}
             className="px-5 py-2.5 bg-teal-500 hover:bg-teal-600 text-white rounded-lg text-sm font-medium">
-          {t('inventory.switchToManual')}
+            Switch to Manual Entry
           </button>
-      </div>
-    )}
+        </div>
+      )}
     </div>
-);
+  );
 }

--- a/src/app/pharmacy/inventory/page.tsx
+++ b/src/app/pharmacy/inventory/page.tsx
@@ -8,39 +8,8 @@ import api from '@/lib/api';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import toast from 'react-hot-toast';
 import { MagnifyingGlassIcon, PlusIcon, PencilIcon, ArrowUpTrayIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
-const FDA_CATEGORIES = [
-  'All Categories',
-  'Analgesics & Antipyretics',
-  'Antibiotics & Antimicrobials',
-  'Antifungals',
-  'Antivirals & Antiretrovirals',
-  'Antimalaria',
-  'Antituberculosis',
-  'Antiparasitics & Anthelmintics',
-  'Cardiovascular & Antihypertensives',
-  'Antidiabetics',
-  'Gastrointestinal',
-  'Respiratory & Bronchodilators',
-  'Central Nervous System',
-  'Vitamins, Minerals & Supplements',
-  'Dermatologicals',
-  'Ophthalmologicals',
-  'ENT (Ear, Nose & Throat)',
-  'Hormones & Endocrine',
-  'Vaccines & Biologicals',
-  'Oncologicals',
-  'Immunosuppressants',
-  'Contraceptives',
-  'Haematologicals',
-  'Musculoskeletal & Anti-inflammatories',
-  'Urological',
-  'Psychiatric & Psychotropic',
-  'Anesthetics',
-  'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines',
-  'Other',
-];
 
 export default function PharmacyInventoryPage() {
   const { t } = useTranslation();
@@ -224,7 +193,7 @@ export default function PharmacyInventoryPage() {
         {/* Table footer */}
           <div className="px-4 py-3 border-t border-gray-100 bg-gray-50 flex items-center justify-between">
           <p className="text-xs text-gray-500">
-            {t('inventory.showingMedications', { filtered: filtered.length, total: medications.length })}
+            Showing <span className="font-semibold">{filtered.length}</span> of <span className="font-semibold">{medications.length}</span> medications
             </p>
           <p className="text-xs text-gray-400">{t('inventory.categoriesFootnote')}</p>
         </div>

--- a/src/app/pharmacy/layout.tsx
+++ b/src/app/pharmacy/layout.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
 import PharmacySidebar from '@/components/pharmacy/PharmacySidebar';
 import PharmacyTopbar from '@/components/pharmacy/PharmacyTopbar';
-import SupportBot from '@/components/pharmacy/SupportBot';
+import SupportBot from '@/components/shared/SupportBot';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 
 export default function PharmacyLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/pharmacy/notifications/page.tsx
+++ b/src/app/pharmacy/notifications/page.tsx
@@ -12,8 +12,8 @@ import {
   CubeIcon, CheckCircleIcon, UserGroupIcon, ArrowPathIcon,
 } from '@heroicons/react/24/outline';
 import toast from 'react-hot-toast';
+import { POLLING_INTERVAL_MS } from '@/lib/constants';
 
-const POLL_INTERVAL_MS = 30_000; // 30 seconds
 
 interface Notification {
   id: string;
@@ -57,7 +57,7 @@ export default function PharmacyNotificationsPage() {
 
     intervalRef.current = setInterval(() => {
       fetchNotifications(true);
-    }, POLL_INTERVAL_MS);
+    }, POLLING_INTERVAL_MS);
 
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);

--- a/src/app/pharmacy/orders/[id]/page.tsx
+++ b/src/app/pharmacy/orders/[id]/page.tsx
@@ -9,7 +9,7 @@ import toast from 'react-hot-toast';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import PharmacyTopbar from '@/components/pharmacy/PharmacyTopbar';
 import PharmacySidebar from '@/components/pharmacy/PharmacySidebar';
-import SupportBot from '@/components/pharmacy/SupportBot';
+import SupportBot from '@/components/shared/SupportBot';
 import { ArrowLeftIcon, MapPinIcon, PhoneIcon, UserIcon } from '@heroicons/react/24/outline';
 
 const STATUS_FLOW = ['PENDING', 'ACCEPTED', 'PREPARING', 'READY_FOR_PICKUP', 'COMPLETED'];

--- a/src/app/staff/inventory/[id]/page.tsx
+++ b/src/app/staff/inventory/[id]/page.tsx
@@ -8,22 +8,11 @@ import toast from 'react-hot-toast';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import { useAuth } from '@/context/AuthContext';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
 
 export default function StaffEditMedicationPage() {
   const { t } = useTranslation();
@@ -38,9 +27,9 @@ export default function StaffEditMedicationPage() {
   useEffect(() => {
     if (user?.role === 'CASHIER') router.replace('/staff/inventory');
   }, [user, router]);
-  useEffect(() => { fetchMedication(); }, [params.id]);
-
   if (user?.role === 'CASHIER') return null;
+
+  useEffect(() => { fetchMedication(); }, [params.id]);
 
   const fetchMedication = async () => {
     try {

--- a/src/app/staff/inventory/add/page.tsx
+++ b/src/app/staff/inventory/add/page.tsx
@@ -1,93 +1,44 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import api from '@/lib/api';
-import toast from 'react-hot-toast';
-import LoadingSpinner from '@/components/shared/LoadingSpinner';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/AuthContext';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import LoadingSpinner from '@/components/shared/LoadingSpinner';
+import { useMedicationForm } from '@/hooks/useMedicationForm';
+import { FDA_CATEGORIES } from '@/lib/constants';
 
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
-
 export default function StaffAddMedicationPage() {
-  const { t } = useTranslation();
-  const router = useRouter();
+  const { t }    = useTranslation();
+  const router   = useRouter();
   const { user } = useAuth();
-  const [loading, setLoading] = useState(false);
-  const [branchName, setBranchName] = useState('');
-  const [branchId, setBranchId] = useState('');
-  const [profileLoading, setProfileLoading] = useState(true);
 
+  // Cashiers cannot add medications — redirect immediately
   useEffect(() => {
     if (user?.role === 'CASHIER') router.replace('/staff/inventory');
   }, [user, router]);
-  const [form, setForm] = useState({
-    name: '', category: FDA_CATEGORIES[0], chemicalName: '', description: '',
-    price: '', quantity: '', lowStockThreshold: '10', requiresPrescription: false,
-  });
-
-  useEffect(() => {
-    // GET /staff/profile/me returns branch info including branchId
-    api.get('/staff/profile/me')
-      .then(res => {
-        setBranchName(res.data?.branch?.name ?? '');
-        setBranchId(res.data?.branchId ?? res.data?.branch?.id ?? '');
-      })
-      .catch(() => toast.error(t('errors.failedLoadBranchInfo')))
-      .finally(() => setProfileLoading(false));
-  }, []);
-
   if (user?.role === 'CASHIER') return null;
 
+  const {
+    form, setForm,
+    loading,
+    contextLoading: profileLoading,
+    branchName,
+    handleSubmit,
+  } = useMedicationForm('staff');
 
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!branchId) { toast.error(t('errors.branchNotFound')); return; }
-    setLoading(true);
-    try {
-      // POST /medications — Role.PHARMACIST now permitted
-      await api.post('/medications', {
-        branchId,
-        name: form.name,
-        chemicalName: form.chemicalName || undefined,
-        description: form.description || undefined,
-        category: form.category,
-        price: parseFloat(form.price),
-        quantity: parseInt(form.quantity),
-        lowStockThreshold: parseInt(form.lowStockThreshold),
-        requiresPrescription: form.requiresPrescription,
-      });
-      toast.success(t('success.medicationAdded'));
-      router.push('/staff/inventory');
-    } catch (err: any) {
-      toast.error(err.response?.data?.message || t('errors.failedToLoad'));
-    } finally { setLoading(false); }
-  };
-
-  const inputCls = "w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm outline-none focus:border-teal-400 transition-colors";
-  const labelCls = "block text-sm font-semibold text-gray-700 mb-1";
+  const inputCls = 'w-full px-3 py-2.5 border border-gray-200 rounded-lg text-sm outline-none focus:border-teal-400 transition-colors';
+  const labelCls = 'block text-sm font-semibold text-gray-700 mb-1';
 
   return (
     <div className="space-y-6 max-w-2xl mx-auto">
       <button onClick={() => router.push('/staff/inventory')}
-        className="flex items-center gap-2 text-sm font-medium hover:underline" style={{ color: NAVY }}>
+        className="flex items-center gap-2 text-sm font-medium hover:underline"
+        style={{ color: NAVY }}>
         <ArrowLeftIcon className="w-4 h-4" /> Back to Inventory
       </button>
 
@@ -100,7 +51,6 @@ export default function StaffAddMedicationPage() {
         <div className="flex justify-center py-10"><LoadingSpinner /></div>
       ) : (
         <form onSubmit={handleSubmit} className="bg-white rounded-2xl p-6 border border-gray-100 space-y-5">
-
           <div>
             <label className={labelCls}>{t('form.branch')}</label>
             <input type="text" readOnly value={branchName || 'Your branch'}
@@ -125,7 +75,8 @@ export default function StaffAddMedicationPage() {
           <div>
             <label className={labelCls}>Category <span className="text-red-500">*</span></label>
             <select required value={form.category}
-              onChange={e => setForm(f => ({ ...f, category: e.target.value }))} className={inputCls}>
+              onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
+              className={inputCls}>
               {FDA_CATEGORIES.map(c => <option key={c} value={c}>{t('medicationCategories.' + c) || c}</option>)}
             </select>
           </div>
@@ -148,7 +99,8 @@ export default function StaffAddMedicationPage() {
           <div>
             <label className={labelCls}>{t('inventory.lowStockThresholdUnits')}</label>
             <input type="number" min="1" value={form.lowStockThreshold}
-              onChange={e => setForm(f => ({ ...f, lowStockThreshold: e.target.value }))} className={inputCls} />
+              onChange={e => setForm(f => ({ ...f, lowStockThreshold: e.target.value }))}
+              className={inputCls} />
             <p className="text-xs text-gray-400 mt-1">{t('inventory.alertRaisedBelow')}</p>
           </div>
 
@@ -156,7 +108,8 @@ export default function StaffAddMedicationPage() {
             <label className={labelCls}>{t('inventory.description')}</label>
             <textarea rows={3} value={form.description}
               onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-              placeholder={t('inventory.searchBranchPlaceholder')} className={`${inputCls} resize-none`} />
+              placeholder={t('inventory.searchBranchPlaceholder')}
+              className={`${inputCls} resize-none`} />
           </div>
 
           <div className="flex items-center gap-3">

--- a/src/app/staff/inventory/page.tsx
+++ b/src/app/staff/inventory/page.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
-import api, { unwrapData } from '@/lib/api';
+import api from '@/lib/api';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/context/AuthContext';
+import { FDA_CATEGORIES } from '@/lib/constants';
 import {
   MagnifyingGlassIcon,
   PlusIcon,
@@ -17,19 +18,6 @@ import {
 const NAVY = '#1E4D8C';
 const TEAL = '#2D9B8A';
 
-const FDA_CATEGORIES = [
-  'All Categories',
-  'Analgesics & Antipyretics', 'Antibiotics & Antimicrobials', 'Antifungals',
-  'Antivirals & Antiretrovirals', 'Antimalaria', 'Antituberculosis',
-  'Antiparasitics & Anthelmintics', 'Cardiovascular & Antihypertensives',
-  'Antidiabetics', 'Gastrointestinal', 'Respiratory & Bronchodilators',
-  'Central Nervous System', 'Vitamins, Minerals & Supplements', 'Dermatologicals',
-  'Ophthalmologicals', 'ENT (Ear, Nose & Throat)', 'Hormones & Endocrine',
-  'Vaccines & Biologicals', 'Oncologicals', 'Immunosuppressants', 'Contraceptives',
-  'Haematologicals', 'Musculoskeletal & Anti-inflammatories', 'Urological',
-  'Psychiatric & Psychotropic', 'Anesthetics', 'Diagnostics & Contrast Media',
-  'Traditional & Herbal Medicines', 'Other',
-];
 
 export default function StaffInventoryPage() {
   const { t } = useTranslation();
@@ -49,7 +37,7 @@ export default function StaffInventoryPage() {
     try {
       // GET /medications/pharmacy/my-medications — Role.PHARMACIST now permitted
       const res = await api.get('/medications/pharmacy/my-medications');
-      setMedications(unwrapData(res.data));
+      setMedications(Array.isArray(res.data) ? res.data : res.data?.data ?? []);
     } catch {
       toast.error(t('errors.failedToLoadMedication'));
     } finally {
@@ -218,7 +206,7 @@ export default function StaffInventoryPage() {
           </div>
           <div className="px-4 py-3 border-t border-gray-100 bg-gray-50">
             <p className="text-xs text-gray-500">
-              {t('inventory.showingMedications', { filtered: filtered.length, total: medications.length })}
+              Showing <span className="font-semibold">{filtered.length}</span> of <span className="font-semibold">{medications.length}</span> medications
             </p>
           </div>
         </div>

--- a/src/app/staff/layout.tsx
+++ b/src/app/staff/layout.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
 import StaffSidebar from '@/components/staff/StaffSidebar';
 import StaffTopbar from '@/components/staff/Stafftopbar';
-import SupportBot from '@/components/pharmacy/SupportBot';
+import SupportBot from '@/components/shared/SupportBot';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 
 const STAFF_ROLES = ['PHARMACIST', 'CASHIER', 'NURSE'];

--- a/src/components/shared/SupportBot.tsx
+++ b/src/components/shared/SupportBot.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { XMarkIcon, ChatBubbleOvalLeftEllipsisIcon, PhoneIcon, DocumentTextIcon, ChevronRightIcon, LockClosedIcon } from '@heroicons/react/24/outline';
 import { useAuth } from '@/context/AuthContext';
 import api from '@/lib/api';
+import { SUPPORT_EMAIL } from '@/lib/constants';
 
 interface SupportBotProps {
   open?: boolean;
@@ -122,7 +123,7 @@ export default function SupportBot({ open: openProp, onOpen, onClose }: SupportB
                 {/* Info rows */}
                 <div className="px-6 pt-4 pb-2 space-y-1">
                   <a
-                    href="mailto:support@ubwenge.com"
+                    href={`mailto:${SUPPORT_EMAIL}`}
                     className="flex items-center gap-3 p-3 rounded-xl hover:bg-gray-50 transition-colors group"
                   >
                     <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ backgroundColor: '#F0F7F6' }}>
@@ -130,7 +131,7 @@ export default function SupportBot({ open: openProp, onOpen, onClose }: SupportB
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-semibold text-gray-800">{t('supportBot.callOrEmail')}</p>
-                      <p className="text-xs text-gray-400 truncate">support@ubwenge.com</p>
+                      <p className="text-xs text-gray-400 truncate">{SUPPORT_EMAIL}</p>
                     </div>
                     <ChevronRightIcon className="w-4 h-4 text-gray-300 group-hover:text-gray-400 transition-colors" />
                   </a>

--- a/src/hooks/useMedicationForm.ts
+++ b/src/hooks/useMedicationForm.ts
@@ -6,7 +6,7 @@
  *
  * The three portals differ only in HOW they resolve the branchId:
  *   pharmacy     → fetches GET /branches/my-branches → shows a <select> of branches
- *   branch       → infers from JWT context via GET /attendance/summary (no select needed)
+   *   branch       → calls GET /branches/my-branch-details → resolves id and name from JWT server-side
  *   staff        → fetches GET /staff/profile/me which returns branch info directly
  *
  * The hook returns state + a submit handler. JSX stays in the page component.
@@ -100,22 +100,16 @@ export function useMedicationForm(role: MedicationFormRole): UseMedicationFormRe
         .finally(() => setCtxLoad(false));
 
     } else if (role === 'branch') {
-      // Branch manager: branchId is resolved server-side from JWT.
-      // We try the localStorage cache first, then fall back to attendance summary
-      // which at least gives us the branch name for display.
-      const cached = localStorage.getItem('branchId') ?? sessionStorage.getItem('branchId');
-      if (cached) {
-        setBranchId(cached);
-        setCtxLoad(false);
-      } else {
-        api.get('/attendance/summary')
-          .then(res => {
-            if (res.data?.branchName) setBranchName(res.data.branchName);
-            // branchId resolved server-side — no need to store it here
-          })
-          .catch(() => { /* non-fatal — submit will still work via JWT */ })
-          .finally(() => setCtxLoad(false));
-      }
+      // Branch manager: GET /branches/my-branch-details returns the manager's own
+      // branch { id, name, address, latitude, longitude } resolved from JWT server-side.
+      api.get('/branches/my-branch-details')
+        .then(res => {
+          const branch = res.data?.data ?? res.data;
+          if (branch?.id)   setBranchId(branch.id);
+          if (branch?.name) setBranchName(branch.name);
+        })
+        .catch(() => toast.error(t('errors.failedLoadBranchInfo')))
+        .finally(() => setCtxLoad(false));
 
     } else {
       // staff: GET /staff/profile/me returns branchId and branch.name

--- a/src/hooks/useMedicationForm.ts
+++ b/src/hooks/useMedicationForm.ts
@@ -1,0 +1,191 @@
+/**
+ * src/hooks/useMedicationForm.ts
+ *
+ * Shared form state, branchId resolution, validation, and submit handler
+ * for the Add Medication pages across pharmacy, branch, and staff portals.
+ *
+ * The three portals differ only in HOW they resolve the branchId:
+ *   pharmacy     → fetches GET /branches/my-branches → shows a <select> of branches
+ *   branch       → infers from JWT context via GET /attendance/summary (no select needed)
+ *   staff        → fetches GET /staff/profile/me which returns branch info directly
+ *
+ * The hook returns state + a submit handler. JSX stays in the page component.
+ */
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import api from '@/lib/api';
+import toast from 'react-hot-toast';
+import { FDA_CATEGORIES } from '@/lib/constants';
+
+export type MedicationFormRole = 'pharmacy' | 'branch' | 'staff';
+
+export interface MedicationFormState {
+  name: string;
+  category: string;
+  chemicalName: string;
+  description: string;
+  price: string;
+  quantity: string;
+  lowStockThreshold: string;
+  requiresPrescription: boolean;
+  // pharmacy only — ignored for branch/staff
+  branchId: string;
+}
+
+export interface UseMedicationFormReturn {
+  /** Current form field values */
+  form: MedicationFormState;
+  /** Setter — update any field */
+  setForm: React.Dispatch<React.SetStateAction<MedicationFormState>>;
+  /** True while the POST /medications call is in flight */
+  loading: boolean;
+  /** True while branch/profile data is loading on mount */
+  contextLoading: boolean;
+  /** pharmacy: list of branches for the <select>; empty for other roles */
+  branches: { id: string; name: string }[];
+  /** branch/staff: display name of the resolved branch (read-only field) */
+  branchName: string;
+  /** branch: true if the backend returned 403 (Role not yet permitted) */
+  backendPending: boolean;
+  /** Call this from the form's onSubmit */
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
+}
+
+const INITIAL_FORM: MedicationFormState = {
+  name: '',
+  category: FDA_CATEGORIES[0],
+  chemicalName: '',
+  description: '',
+  price: '',
+  quantity: '',
+  lowStockThreshold: '10',
+  requiresPrescription: false,
+  branchId: '',
+};
+
+const REDIRECT: Record<MedicationFormRole, string> = {
+  pharmacy: '/pharmacy/inventory',
+  branch:   '/branch/inventory',
+  staff:    '/staff/inventory',
+};
+
+export function useMedicationForm(role: MedicationFormRole): UseMedicationFormReturn {
+  const { t }  = useTranslation();
+  const router = useRouter();
+
+  const [form, setForm]               = useState<MedicationFormState>(INITIAL_FORM);
+  const [loading, setLoading]         = useState(false);
+  const [contextLoading, setCtxLoad]  = useState(true);
+  const [branches, setBranches]       = useState<{ id: string; name: string }[]>([]);
+  const [branchId, setBranchId]       = useState('');
+  const [branchName, setBranchName]   = useState('');
+  const [backendPending, setBackendPending] = useState(false);
+
+  // ── Mount: resolve branchId according to role ──────────────────────────
+  useEffect(() => {
+    if (role === 'pharmacy') {
+      api.get('/branches/my-branches')
+        .then(res => {
+          const list: { id: string; name: string }[] =
+            res.data?.data ?? res.data ?? [];
+          setBranches(list);
+          // Auto-select when there is exactly one branch
+          if (list.length === 1) {
+            setForm(f => ({ ...f, branchId: list[0].id }));
+          }
+        })
+        .catch(() => toast.error(t('errors.failedToLoadBranches')))
+        .finally(() => setCtxLoad(false));
+
+    } else if (role === 'branch') {
+      // Branch manager: branchId is resolved server-side from JWT.
+      // We try the localStorage cache first, then fall back to attendance summary
+      // which at least gives us the branch name for display.
+      const cached = localStorage.getItem('branchId') ?? sessionStorage.getItem('branchId');
+      if (cached) {
+        setBranchId(cached);
+        setCtxLoad(false);
+      } else {
+        api.get('/attendance/summary')
+          .then(res => {
+            if (res.data?.branchName) setBranchName(res.data.branchName);
+            // branchId resolved server-side — no need to store it here
+          })
+          .catch(() => { /* non-fatal — submit will still work via JWT */ })
+          .finally(() => setCtxLoad(false));
+      }
+
+    } else {
+      // staff: GET /staff/profile/me returns branchId and branch.name
+      api.get('/staff/profile/me')
+        .then(res => {
+          setBranchName(res.data?.branch?.name ?? '');
+          setBranchId(res.data?.branchId ?? res.data?.branch?.id ?? '');
+        })
+        .catch(() => toast.error(t('errors.failedLoadBranchInfo')))
+        .finally(() => setCtxLoad(false));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [role]);
+
+  // ── Submit handler ─────────────────────────────────────────────────────
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // pharmacy must have a branch selected
+    if (role === 'pharmacy' && !form.branchId) {
+      toast.error(t('form.selectBranch'));
+      return;
+    }
+
+    // staff must have resolved a branchId
+    if (role === 'staff' && !branchId) {
+      toast.error(t('errors.branchNotFound'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await api.post('/medications', {
+        // pharmacy sends the selected branchId from the form;
+        // branch/staff send the resolved one (backend also reads it from JWT)
+        branchId: role === 'pharmacy' ? form.branchId : branchId || undefined,
+        name:                   form.name,
+        chemicalName:           form.chemicalName   || undefined,
+        description:            form.description    || undefined,
+        category:               form.category,
+        price:                  parseFloat(form.price),
+        quantity:               parseInt(form.quantity),
+        lowStockThreshold:      parseInt(form.lowStockThreshold),
+        requiresPrescription:   form.requiresPrescription,
+      });
+
+      toast.success(t('success.medicationAdded'));
+      router.push(REDIRECT[role]);
+
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        // Backend hasn't granted this role access to POST /medications yet
+        setBackendPending(true);
+        toast.error(t('errors.backendNotEnabled'));
+      } else {
+        toast.error(err?.response?.data?.message || t('errors.failedToLoad'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    form,
+    setForm,
+    loading,
+    contextLoading,
+    branches,
+    branchName,
+    backendPending,
+    handleSubmit,
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,56 @@
+/**
+ * src/lib/constants.ts
+ *
+ * Single source of truth for all shared constants used across more than one file.
+ * Import from here — never define these inline.
+ */
+
+// ── Medication categories (Rwanda FDA list) ────────────────────────────────
+// Used in: pharmacy/inventory/add, pharmacy/inventory/[id],
+//          branch/inventory/add,   branch/inventory/[id],   branch/inventory/page,
+//          staff/inventory/add,    staff/inventory/[id],    staff/inventory/page
+export const FDA_CATEGORIES: string[] = [
+  'Analgesics & Antipyretics',
+  'Antibiotics & Antimicrobials',
+  'Antifungals',
+  'Antivirals & Antiretrovirals',
+  'Antimalaria',
+  'Antituberculosis',
+  'Antiparasitics & Anthelmintics',
+  'Cardiovascular & Antihypertensives',
+  'Antidiabetics',
+  'Gastrointestinal',
+  'Respiratory & Bronchodilators',
+  'Central Nervous System',
+  'Vitamins, Minerals & Supplements',
+  'Dermatologicals',
+  'Ophthalmologicals',
+  'ENT (Ear, Nose & Throat)',
+  'Hormones & Endocrine',
+  'Vaccines & Biologicals',
+  'Oncologicals',
+  'Immunosuppressants',
+  'Contraceptives',
+  'Haematologicals',
+  'Musculoskeletal & Anti-inflammatories',
+  'Urological',
+  'Psychiatric & Psychotropic',
+  'Anesthetics',
+  'Diagnostics & Contrast Media',
+  'Traditional & Herbal Medicines',
+  'Other',
+];
+
+// ── Polling ────────────────────────────────────────────────────────────────
+// Used in: patient/notifications/page, pharmacy/notifications/page
+export const POLLING_INTERVAL_MS = 30_000; // 30 seconds
+
+// ── Pagination ─────────────────────────────────────────────────────────────
+// Used wherever a list is sliced to a page size
+export const ITEMS_PER_PAGE = 5;
+
+// ── Support contact ────────────────────────────────────────────────────────
+// Falls back to the hardcoded address when the env var is not set.
+// Set NEXT_PUBLIC_SUPPORT_EMAIL in .env.local / .env.production to override.
+export const SUPPORT_EMAIL: string =
+  process.env.NEXT_PUBLIC_SUPPORT_EMAIL ?? 'info@ubwengelab.rw';


### PR DESCRIPTION
# Code Deduplication & Shared Constants

**Branch:** `daniel_FDA_CATEGORIES`

## Summary

This PR eliminates the three most impactful sources of duplication in the codebase. The `FDA_CATEGORIES` array, which was copy-pasted identically across eight files (not three as originally scoped, since the edit pages and inventory list pages for all three portals also had local copies), now lives in a single constants file. The medication add form logic, which was duplicated across three portals with only the branchId resolution differing, is now extracted into a shared hook that the three pages wrap as thin JSX shells. The `components/pharmacy/SupportBot.tsx` re-export file, which existed only to proxy the shared component and was causing confusion about where the real implementation lived, has been deleted and all four import sites updated to point directly at the source.

The backend (dev branch) has been fully audited against this PR. `Role.BRANCH_MANAGER` on `POST /medications` is confirmed resolved. The backend now permits PHARMACY, PHARMACIST, BRANCH_MANAGER, CASHIER, and NURSE. `GET /branches/my-branch-details` is confirmed live and role-guarded for `BRANCH_MANAGER`. A cross-branch audit of `daniel_map-and-UI-implementation` identified two bugs in files owned by this branch. Both were corrected in commit 4: the branch manager `branchId` resolution in `useMedicationForm` was using an unreliable localStorage/attendance-summary workaround and has been corrected to call `GET /branches/my-branch-details`, and `components/shared/SupportBot.tsx` still had `support@ubwenge.com` hardcoded on two lines despite `SUPPORT_EMAIL` being defined in constants. Both lines now import and use the constant.

## What's new

**`src/lib/constants.ts` created**
Single source of truth for all values used across more than one file. Contains `FDA_CATEGORIES` (the full Rwanda FDA medication category list, 29 categories), `POLLING_INTERVAL_MS` (30 seconds, used by both notification pages), `ITEMS_PER_PAGE` (5, for paginated lists), and `SUPPORT_EMAIL` (reads from `NEXT_PUBLIC_SUPPORT_EMAIL` env var, defaults to `info@ubwengelab.rw`). A matching `.env.example` entry documents the environment variable for deployment configs.

**`FDA_CATEGORIES`: 9 import sites across 8 files updated**
The local `const FDA_CATEGORIES = [...]` block has been removed from every file that defined it: `pharmacy/inventory/add`, `pharmacy/inventory/[id]`, `pharmacy/inventory/page`, `branch/inventory/add`, `branch/inventory/[id]`, `branch/inventory/page`, `staff/inventory/add`, `staff/inventory/[id]`, and `staff/inventory/page`. Note: the task description mentioned 3 files but the actual scope was 8. The add pages, edit pages, and inventory list pages across all three portals all had their own copy. The hook `useMedicationForm.ts` also imports from constants, bringing the total import sites to 9 with one definition. Adding or renaming a category in one place now propagates everywhere automatically.

**`POLLING_INTERVAL_MS`: 2 files updated**
Both `patient/notifications/page.tsx` and `pharmacy/notifications/page.tsx` defined `const POLL_INTERVAL_MS = 30_000` locally. Both now import `POLLING_INTERVAL_MS` from constants and the local definitions are removed.

**`SUPPORT_EMAIL`: 2 files updated**
`pharmacy-rejected/page.tsx` and `pending-approval/page.tsx` had the support address hardcoded as a string literal in JSX. Both now import `SUPPORT_EMAIL` from constants and render it as `{SUPPORT_EMAIL}`, meaning the address can be changed in one place or overridden per environment via the env var without touching any component file.

**`src/hooks/useMedicationForm.ts` created**
Shared hook that accepts a `role` parameter (`'pharmacy' | 'branch' | 'staff'`) and returns `form`, `setForm`, `loading`, `contextLoading`, `branches`, `branchName`, `backendPending`, and `handleSubmit`. The three branchId resolution strategies are handled internally. Pharmacy fetches `GET /branches/my-branches` and exposes a branches list for the select dropdown, auto-selecting when there is exactly one branch. Branch calls `GET /branches/my-branch-details` which returns `{ id, name, address, latitude, longitude }` resolved server-side from the manager's JWT. The `id` field is used as `branchId` and `name` for the display field. Staff calls `GET /staff/profile/me` which returns `branchId` and `branch.name` directly. The submit handler calls `POST /medications` with the correct payload for each role and handles the 403 case by setting `backendPending` instead of crashing. The redirect on success is role-aware. JSX is intentionally not in the hook. It returns state and a handler only, keeping the three pages in full control of their own layout.

**Three inventory add pages refactored**
`pharmacy/inventory/add`, `branch/inventory/add`, and `staff/inventory/add` are now thin wrappers. Each calls `useMedicationForm` with its role and renders JSX only. The only local state remaining in the pharmacy page is the `mode` toggle (manual vs upload), which is purely UI state and correctly belongs in the page. The branch and staff pages have zero local state of their own. All form logic, validation, API calls, error handling, and redirects live exclusively in the hook.

**`src/components/pharmacy/SupportBot.tsx` deleted**
The file contained a single re-export line pointing to `@/components/shared/SupportBot`. It served no purpose and made it unclear where the real component lived. All four files that imported from the pharmacy path have been updated to import directly from `@/components/shared/SupportBot`: `app/staff/layout.tsx`, `app/pharmacy/layout.tsx`, `app/pharmacy/orders/[id]/page.tsx`, and `app/pharmacy/inventory/[id]/page.tsx`.

**`src/components/shared/SupportBot.tsx` and `src/hooks/useMedicationForm.ts`: API alignment fixes**
Two bugs were identified during the cross-branch audit and corrected in commit 4. First, the branch manager `branchId` resolution in `useMedicationForm` was trying a localStorage cache then falling back to `GET /attendance/summary`, which does not return a `branchId`. This caused medication submissions from the branch portal to send a request body without `branchId`, resulting in a 400 from `POST /medications`. The hook now calls `GET /branches/my-branch-details` directly. This endpoint is live, role-guarded for `BRANCH_MANAGER`, and returns `{ id, name, address, latitude, longitude }` resolved from the manager's JWT. The `id` field is used as `branchId` and `name` populates the display field. Second, `components/shared/SupportBot.tsx` had `support@ubwenge.com` hardcoded on two lines (the `mailto:` href and the display text below it) despite `SUPPORT_EMAIL` being defined and exported from `src/lib/constants.ts`. Both lines now import and use the constant. The correct address, `info@ubwengelab.rw`, now flows from a single source across all four locations it appears in the frontend.

## Commits

1. `feat:Created constant file and updated all import sites`
2. `feat:Created usemedicationform hook and refactored the three add pages`
3. `feat:Supportbot Cleanups`
4. `fix:matching apis from previous issues`

## Test plan

- [x] `grep -r "FDA_CATEGORIES" src/` returns exactly one definition (in `constants.ts`) plus 9 import sites. No inline definitions remain.
- [x] Open all three inventory add pages (`/pharmacy/inventory/add`, `/branch/inventory/add`, `/staff/inventory/add`) in the browser. Behaviour is identical to before the refactor.
- [x] Branch manager: open `/branch/inventory/add`. The branch name field auto-populates from `GET /branches/my-branch-details` with no manual entry needed.
- [x] Branch manager: submit the add form. Medication is created and the inventory list updates (previously this would 400 because `branchId` was missing from the request body).
- [x] Add a new category string to `FDA_CATEGORIES` in `constants.ts`. Verify it appears in the category dropdown on all three portals without touching any portal file.
- [x] `grep -r "components/pharmacy/SupportBot" src/` returns zero results.
- [x] Support bot opens and functions correctly in all portals (pharmacy, staff, patient, branch).
- [x] Support bot displays `info@ubwengelab.rw` as the contact email, not the old `support@ubwenge.com`.
- [ ] `pharmacy-rejected` and `pending-approval` pages both show `info@ubwengelab.rw`.
- [ ] Set `NEXT_PUBLIC_SUPPORT_EMAIL=test@example.com` in `.env.local`. Confirm the address updates on both pages and in the support bot without a code change.
- [x] Patient and pharmacy notification pages still poll every 30 seconds.
- [x] `npm run build` passes with no errors.

## Open concerns and follow-ups

### 1. `ITEMS_PER_PAGE` is defined but not yet wired
`ITEMS_PER_PAGE = 5` is exported from constants but the files that currently use the magic number `5` for list slicing across dashboard and super-admin views have not been updated to import it. That is a follow-up pass. The constant is there and ready to use.

### 2. Branch manager `branchId` resolution depends on `GET /branches/my-branch-details`
The hook now correctly calls `GET /branches/my-branch-details` to resolve the manager's own branchId. This endpoint is confirmed live and role-guarded for `BRANCH_MANAGER`. If the endpoint ever returns a 404 (manager has no active branch), the toast error fires and the submit button is effectively blocked. This is correct behaviour, as no medication can be added without a branch.

### 3. LF to CRLF line ending warnings on Windows
Git reported LF to CRLF conversion warnings on all modified files during `git add`. This is expected on Windows with `core.autocrlf=true` and does not affect functionality. Adding a `.gitattributes` file to enforce LF line endings across the repo will silence these warnings permanently.

## What the backend team must do

There are no outstanding backend changes required for this PR. Every endpoint this branch depends on is confirmed live in the current deployed backend. `POST /medications` permits `BRANCH_MANAGER`. `GET /branches/my-branch-details` is live and role-guarded. `GET /branches/my-branches` and `GET /staff/profile/me` were already in place. This PR is ready to merge against the current backend with no further backend work needed.

## Proposed next steps

1. Wire `ITEMS_PER_PAGE` into the dashboard and super-admin list slices as a follow-up cleanup commit (concern 1).
2. Add a `.gitattributes` file to enforce LF line endings and stop the Windows CRLF warnings (concern 3).