### PR TITLE
feat(cashier): redesign cashier orders view to match premium Figma mo…

### DIFF
--- a/src/components/staff/CashierOrdersView.tsx
+++ b/src/components/staff/CashierOrdersView.tsx
@@ -63,112 +63,152 @@ export default function CashierOrdersView({ orders, loading }: CashierOrdersView
   }
 
   return (
-    <div className="space-y-6">
-      {/* Hero */}
-      <div className="rounded-2xl p-6 lg:p-8 text-white" style={{ backgroundColor: NAVY }}>
-        <h1 className="text-2xl lg:text-3xl font-bold">{t('cashier.ordersTitle')}</h1>
-        <p className="mt-1 text-white/70">{t('cashier.ordersSubtitle')}</p>
+    <div className="space-y-6 max-w-6xl mx-auto">
+      {/* Hero Banner */}
+      <div className="rounded-2xl p-6 lg:p-8 border border-blue-100 bg-linear-to-r from-[#E5F1FF] to-[#F3F8FF] shadow-xs">
+        <h1 className="text-2xl lg:text-3xl font-black text-[#1E4D8C]">{t('cashier.ordersTitle') || 'Cashier Portal'}</h1>
+        <p className="mt-1.5 text-blue-700/80 font-semibold text-sm">{t('cashier.ordersSubtitle') || 'Manage client checkouts, payments, and prescription status verification.'}</p>
       </div>
 
-      {/* Stat cards */}
+      {/* Stat Cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         {[
-          { label: t('cashier.tabAll'),             value: orders.length,                                                          dark: false },
-          { label: t('cashier.tabPendingPayment'),  value: orders.filter((o) => STATUS_PENDING_PAYMENT.includes(o.status)).length, dark: false },
-          { label: t('cashier.tabReadyPickup'),     value: orders.filter((o) => STATUS_READY_PICKUP.includes(o.status)).length,    dark: false },
-          { label: t('cashier.tabCompleted'),       value: orders.filter((o) => STATUS_COMPLETED.includes(o.status)).length + advancedIds.size, dark: true },
-        ].map((s) => (
-          <div
-            key={s.label}
-            className="rounded-2xl p-5 flex items-center justify-between"
-            style={{ backgroundColor: s.dark ? NAVY : TEAL }}
-          >
-            <div>
-              <p className="text-white/80 text-sm">{s.label}</p>
-              <p className="text-white text-2xl font-bold mt-1">{s.value}</p>
+          { label: t('cashier.tabAll'),             value: orders.length,                                                          icon: ListOrdered, color: '#1E4D8C', bg: 'bg-blue-50' },
+          { label: t('cashier.tabPendingPayment'),  value: orders.filter((o) => STATUS_PENDING_PAYMENT.includes(o.status)).length, icon: CreditCard,  color: '#2D9B8A', bg: 'bg-teal-50' },
+          { label: t('cashier.tabReadyPickup'),     value: orders.filter((o) => STATUS_READY_PICKUP.includes(o.status)).length,    icon: Package,     color: '#EAB308', bg: 'bg-amber-50' },
+          { label: t('cashier.tabCompleted'),       value: orders.filter((o) => STATUS_COMPLETED.includes(o.status)).length + advancedIds.size, icon: CheckCircle2, color: '#22C55E', bg: 'bg-emerald-50' },
+        ].map((s) => {
+          const Icon = s.icon;
+          return (
+            <div
+              key={s.label}
+              className="bg-white dark:bg-gray-800 rounded-2xl p-5 border border-gray-100 dark:border-gray-700/50 shadow-xs flex items-center justify-between hover:shadow-md transition-all duration-300"
+            >
+              <div>
+                <p className="text-gray-400 dark:text-gray-400 text-xs font-bold uppercase tracking-wider">{s.label}</p>
+                <p className="text-gray-900 dark:text-white text-2xl font-black mt-1">{s.value}</p>
+              </div>
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center shrink-0 ${s.bg}`}>
+                <Icon size={22} style={{ color: s.color }} />
+              </div>
             </div>
-            <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-white/15">
-              <ShoppingCart size={20} className="text-white" />
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
-      {/* Tab pills */}
-      <div className="flex flex-wrap gap-2">
-        {tabs.map(({ key, label, icon: Icon }) => (
-          <button
-            key={key}
-            onClick={() => setTab(key)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
-              tab === key ? 'text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
-            style={tab === key ? { backgroundColor: TEAL } : {}}
-          >
-            <Icon size={13} />
-            {label}
-          </button>
-        ))}
+      {/* Segmented Control Switcher */}
+      <div className="flex bg-[#F0F4FA] dark:bg-gray-800/50 p-1.5 rounded-2xl max-w-2xl border border-gray-200/50 dark:border-gray-700/50">
+        {tabs.map(({ key, label, icon: Icon }) => {
+          const active = tab === key;
+          return (
+            <button
+              key={key}
+              onClick={() => setTab(key)}
+              className={`flex-1 flex items-center justify-center gap-2 py-3 px-4 rounded-xl text-xs font-black transition-all duration-200 ${
+                active
+                  ? 'bg-white dark:bg-gray-700 text-[#1E4D8C] shadow-sm font-black'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
+            >
+              <Icon size={14} className={active ? 'text-[#1E4D8C]' : 'text-gray-400'} />
+              {label}
+            </button>
+          );
+        })}
       </div>
 
-      {/* Orders list */}
+      {/* Orders List */}
       {filtered.length === 0 ? (
-        <div className="bg-white rounded-2xl p-12 text-center border border-gray-100">
-          <ShoppingCart size={48} className="text-gray-200 mx-auto mb-3" />
-          <p className="text-gray-500 font-medium">{t('cashier.noOrders')}</p>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-12 text-center border border-gray-100 dark:border-gray-700 shadow-xs">
+          <ShoppingCart size={48} className="text-gray-200 dark:text-gray-600 mx-auto mb-3" />
+          <p className="text-gray-500 dark:text-gray-400 font-bold text-sm">{t('cashier.noOrders')}</p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-4">
           {filtered.map((o) => {
             const itemCount = o.orderItems.reduce((s, it) => s + it.quantity, 0);
             const isPaid = advancedIds.has(o.id);
             const isPaymentTab = tab === 'pending_payment';
+            const initials = [o.patient?.firstName?.[0], o.patient?.lastName?.[0]].filter(Boolean).join('').toUpperCase() || 'P';
+            const formattedTotal = Number(o.total ?? 0).toLocaleString();
 
             return (
               <div
                 key={o.id}
-                className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-100 dark:border-gray-700 overflow-hidden shadow-xs hover:shadow-md transition-all duration-300 relative group"
               >
-                <div className="p-4 lg:p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                  <div className="flex-1 min-w-0 space-y-2">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <div className="h-9 w-9 rounded-full flex items-center justify-center shrink-0" style={{ backgroundColor: `${NAVY}1a` }}>
-                        <User size={16} style={{ color: NAVY }} />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="font-semibold text-gray-900 truncate">
-                          {o.patient.firstName} {o.patient.lastName}
-                        </p>
-                        <p className="text-xs text-gray-400 font-mono mt-0.5">
-                          #{o.id.slice(0, 8)}
-                        </p>
-                      </div>
-                    </div>
+                {/* Left visual accent indicator */}
+                <div 
+                  className={`absolute left-0 top-0 bottom-0 w-1.5 transition-colors ${
+                    isPaid ? 'bg-emerald-500' : 'bg-[#1E4D8C]'
+                  }`} 
+                />
 
-                    <div className="flex items-center gap-3 text-sm text-gray-500 flex-wrap">
-                      <span className="inline-flex items-center gap-1">
-                        <Package size={13} />
-                        {itemCount} {itemCount === 1 ? t('cashier.item') : t('cashier.items')}
-                      </span>
-                      <span className="font-semibold" style={{ color: NAVY }}>
-                        RWF {Number(o.total ?? 0).toLocaleString()}
-                      </span>
-                      {isPaid && (
-                        <span
-                          className="px-2 py-0.5 rounded-full text-xs font-medium border"
-                          style={{ backgroundColor: `${TEAL}1a`, color: TEAL, borderColor: `${TEAL}4d` }}
-                        >
-                          {t('cashier.paid')}
+                <div className="pl-6 pr-6 py-5 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+                  {/* Left: Patient Initials Avatar & Name */}
+                  <div className="flex items-start sm:items-center gap-4 flex-1 min-w-0">
+                    <div 
+                      className="w-12 h-12 rounded-2xl flex items-center justify-center text-white text-sm font-black shrink-0 shadow-xs"
+                      style={{ background: `linear-gradient(135deg, ${NAVY} 0%, #2563a8 100%)` }}
+                    >
+                      {initials}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="font-extrabold text-gray-900 dark:text-white text-base truncate">
+                          {o.patient.firstName} {o.patient.lastName}
+                        </h3>
+                        <span className="px-2.5 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200/50">
+                          {o.type || 'PICKUP'}
                         </span>
-                      )}
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-gray-400 dark:text-gray-500 mt-1 flex-wrap">
+                        <span className="font-mono bg-gray-50 dark:bg-gray-700/50 px-2 py-0.5 rounded-md border border-gray-100 dark:border-gray-700">
+                          #{o.id.slice(0, 8).toUpperCase()}
+                        </span>
+                        <span>·</span>
+                        <span>{new Date(o.createdAt).toLocaleDateString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+                      </div>
                     </div>
                   </div>
 
+                  {/* Middle: Items summary & Price */}
+                  <div className="flex flex-wrap items-center gap-6 sm:gap-10 shrink-0">
+                    <div className="space-y-0.5">
+                      <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider">{t('cashier.items') || 'Items Count'}</p>
+                      <p className="text-sm font-bold text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+                        <Package size={14} className="text-gray-400" />
+                        {itemCount} {itemCount === 1 ? t('cashier.item') : t('cashier.items')}
+                      </p>
+                    </div>
+
+                    <div className="space-y-0.5">
+                      <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Total Amount</p>
+                      <p className="text-base font-black text-[#1E4D8C] dark:text-[#3baaef] font-mono">
+                        RWF {formattedTotal}
+                      </p>
+                    </div>
+
+                    <div className="space-y-0.5">
+                      <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wider">Status</p>
+                      <div className="flex items-center gap-2">
+                        <span className={`px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider border ${
+                          isPaid 
+                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400 border-emerald-200/50'
+                            : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 border-amber-200/50'
+                        }`}>
+                          {isPaid ? t('cashier.paid') : o.status.replace(/_/g, ' ')}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Right: Payment button */}
                   {isPaymentTab && !isPaid && (
                     <button
                       onClick={() => setActiveOrder(o)}
-                      className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-white text-sm font-medium transition-opacity hover:opacity-90 shrink-0"
-                      style={{ backgroundColor: TEAL }}
+                      className="w-full md:w-auto flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-white text-sm font-bold shadow-md hover:shadow-lg transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] shrink-0"
+                      style={{ background: `linear-gradient(135deg, ${TEAL} 0%, #207a6c 100%)` }}
                     >
                       <CreditCard size={15} />
                       {t('cashier.processPayment')}


### PR DESCRIPTION
This Pull Request delivers the brand new, high-fidelity responsive UI/UX designs for the Cashier portal view to match the Figma mockups. All visual enhancements have been developed using Tailwind CSS while strictly preserving existing business logic, props, and API interaction safety.
🎨 Visual & Aesthetic Changes:
- **Hero Banner**: Swapped the heavy solid-colored block for a sleek light-blue gradient container (`from-[#E5F1FF] to-[#F3F8FF]`) with Navy blue headings (`#1E4D8C`), fully aligning it with the modern layout structures of E-Vuze.
- **Stat Cards**: Standardized on elegant, soft-shadow white cards with distinct title-value typography and custom rounded icon squares housed in status-aware colored backgrounds (Teal, Amber, Blue, and Emerald).
- **Segmented Tab Pills Control**: Designed a premium segmented pill selector to easily toggle checkout list queues. Active pills animate with a soft shadow and high-contrast bold indicators.
- **Checkout Order Cards**:
  - Re-spaced elements and introduced patient initials avatars styled with deep Navy blue gradients.
  - Implemented visual accent indicators (emerald left border for paid, navy for pending checkout).
  - Placed structured columns summarizing item counts, total prices, and clear status pills.
  - Interactive "Process Payment" checkout button with hover scaling effects.
   ⚙️ Technical Checklist:
- [x] Zero TypeScript or layout compile errors (`npx tsc --noEmit` and production builds compile successfully with exit code 0).
- [x] Absolutely zero changes to core props, API calls, or payment logic.
- [x] Retained standard `aria-label` tags for screen readers to keep the application WCAG compliant.