### PR TITLE
modify: fixed order processing branch errors and modified pages for better processing actions

### DIFF
--- a/src/app/patient/checkout/page.tsx
+++ b/src/app/patient/checkout/page.tsx
@@ -88,7 +88,6 @@ export default function CheckoutPage() {
       toast.error(t('form.unableToDeterminePharmacy'));
       return;
     }
-
     setLoading(true);
     try {
       // POST /orders — JSON body matching CreateOrderDto exactly

--- a/src/app/patient/medications/page.tsx
+++ b/src/app/patient/medications/page.tsx
@@ -40,7 +40,7 @@ export default function SearchMedications() {
       price: medication.price,
       quantity: 1,
       pharmacyId: medication.pharmacy?.id || '',
-      branchId: medication.branchId || '',
+      branchId: medication.branchId || medication.branch?.id || '',
       pharmacyName: medication.pharmacy?.name || '',
       requiresPrescription: medication.requiresPrescription,
       imageUrl: medication.imageUrl,

--- a/src/app/patient/orders/[id]/page.tsx
+++ b/src/app/patient/orders/[id]/page.tsx
@@ -20,7 +20,7 @@ const STATUS_LABEL_KEYS: Record<string, string> = {
   READY_FOR_PICKUP: 'orders2.statusReadyForPickup',
   DELIVERED: 'orders2.statusDelivered',
   CANCELLED: 'orders2.statusCancelled',
-  COMPLETED: 'orders2.statusDelivered',
+  COMPLETED: 'orders2.orderCompleted',
 };
 
 const PAYMENT_METHOD_KEYS: Record<string, string> = {
@@ -137,7 +137,17 @@ export default function OrderDetailsPage() {
 
   if (!order) return <div className="text-center py-12"><p className="text-gray-500">{t('orders.notFound')}</p></div>;
 
-  const statusSteps = ['PENDING', 'ACCEPTED', 'PREPARING', order.type === 'DELIVERY' ? 'OUT_FOR_DELIVERY' : 'READY_FOR_PICKUP', 'DELIVERED'];
+  const statusSteps = order.type === 'DELIVERY'
+    ? ['PENDING', 'ACCEPTED', 'PREPARING', 'OUT_FOR_DELIVERY', 'DELIVERED']
+    : ['PENDING', 'ACCEPTED', 'PREPARING', 'READY_FOR_PICKUP', 'COMPLETED'];
+
+  const getCurrentStatusIndex = () => {
+    if (!order) return -1;
+    if (order.status === 'COMPLETED') {
+      return statusSteps.length - 1;
+    }
+    return statusSteps.indexOf(order.status);
+  };
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">
@@ -166,12 +176,13 @@ export default function OrderDetailsPage() {
           <div className="mt-8">
           <div className="flex justify-between items-center">
             {statusSteps.map((status, index) => {
-                const isComplete = statusSteps.indexOf(order.status) >= index;
-                const isCurrent = order.status === status;
+                const currentIdx = getCurrentStatusIndex();
+                const isComplete = currentIdx >= index;
+                const isCurrent = order.status === status || (order.status === 'COMPLETED' && index === statusSteps.length - 1);
                 return (
                   <div key={status} className="flex flex-col items-center flex-1">
                   <div className={`w-12 h-12 rounded-full flex items-center justify-center font-bold transition-all ${isComplete ? 'bg-white text-[#1E4D8C] shadow-lg' : 'bg-white/30 text-white/70'} ${isCurrent ? 'ring-4 ring-white/50 scale-110' : ''}`}>
-                    {isComplete ? '' : index + 1}
+                    {isComplete ? '✓' : index + 1}
                     </div>
                   <p className="text-xs mt-2 text-center text-white/90 font-medium">{t(STATUS_LABEL_KEYS[status] ?? status)}</p>
                 </div>

--- a/src/app/patient/orders/page.tsx
+++ b/src/app/patient/orders/page.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '@/lib/api';
+import Link from 'next/link';
 import LoadingSpinner from '@/components/shared/LoadingSpinner';
 import {
   ClipboardDocumentListIcon,
@@ -341,13 +342,19 @@ function OrderDetailDialog({ order, onClose }: { order: any; onClose: () => void
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 p-4 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+        <div className="shrink-0 p-4 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 flex gap-3">
           <button
             onClick={onClose}
-            className="w-full py-3.5 rounded-2xl font-bold text-sm text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            className="flex-1 py-3.5 rounded-2xl font-bold text-sm text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
           >
             {t('common.close')}
           </button>
+          <Link
+            href={`/patient/orders/${order.id}`}
+            className="flex-1 py-3.5 rounded-2xl font-bold text-sm text-white bg-linear-to-r from-[#1E4D8C] to-[#2D9B8A] hover:opacity-90 transition-opacity text-center flex items-center justify-center"
+          >
+            {t('orders2.manageOrder', 'Manage Order')}
+          </Link>
         </div>
       </div>
     </div>

--- a/src/app/patient/pharmacies/[id]/page.tsx
+++ b/src/app/patient/pharmacies/[id]/page.tsx
@@ -55,7 +55,7 @@ export default function PharmacyDetailsPage() {
       quantity: 1,
       pharmacyId: pharmacy?.id || '',
       pharmacyName: pharmacy?.name || '',
-      branchId: branchId,
+      branchId: medication.branchId || medication.branch?.id || branchId,
       requiresPrescription: medication.requiresPrescription,
       imageUrl: medication.imageUrl,
     });

--- a/src/app/patient/search/page.tsx
+++ b/src/app/patient/search/page.tsx
@@ -139,7 +139,7 @@ export default function SearchPage() {
       price: med.price,
       quantity: 1,
       pharmacyId: med.pharmacy?.id || '',
-      branchId: med.branchId || '',
+      branchId: med.branchId || med.branch?.id || '',
       pharmacyName: med.pharmacy?.name || '',
       requiresPrescription: med.requiresPrescription,
       imageUrl: med.imageUrl,

--- a/src/app/pharmacy/orders/[id]/page.tsx
+++ b/src/app/pharmacy/orders/[id]/page.tsx
@@ -12,7 +12,7 @@ import { ArrowLeftIcon, MapPinIcon, PhoneIcon, UserIcon } from '@heroicons/react
 import { getErrorMessage } from '@/lib/errorHandler';
 
 const STATUS_FLOW = ['PENDING', 'ACCEPTED', 'PREPARING', 'READY_FOR_PICKUP', 'COMPLETED'];
-const DELIVERY_STATUS_FLOW = ['PENDING', 'ACCEPTED', 'PREPARING', 'OUT_FOR_DELIVERY', 'DELIVERED'];
+const DELIVERY_STATUS_FLOW = ['PENDING', 'ACCEPTED', 'PREPARING', 'OUT_FOR_DELIVERY', 'DELIVERED', 'COMPLETED'];
 
 type NextAction = { label: string; status: string; color: string } | null;
 
@@ -136,7 +136,7 @@ export default function PharmacyOrderDetailPage() {
             </div>
 
           {/* Action Buttons */}
-            {order.status !== 'CANCELLED' && order.status !== 'COMPLETED' && order.status !== 'DELIVERED' && (
+            {order.status !== 'CANCELLED' && order.status !== 'COMPLETED' && (
               <div className="flex flex-wrap gap-3">
               {nextAction && (
                   <button onClick={() => handleUpdateStatus(nextAction.status)} disabled={actionLoading}

--- a/src/app/staff/orders/page.tsx
+++ b/src/app/staff/orders/page.tsx
@@ -51,6 +51,9 @@ export default function StaffOrdersPage() {
   const [filter, setFilter] = useState('all');
   const [expanded, setExpanded] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [rejectingOrderId, setRejectingOrderId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [showRejectModal, setShowRejectModal] = useState(false);
 
   const { data: fetchedOrders = [], loading, error } = useFetch<Order[]>(
     async (signal) => {
@@ -77,6 +80,32 @@ export default function StaffOrdersPage() {
         prev.map(o => o.id === orderId ? ({ ...o, status: newStatus } as Order) : o)
       );
       toast.success(`Order marked as ${newStatus.replace(/_/g, ' ').toLowerCase()}`);
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error));
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const handleRejectOrder = async () => {
+    if (!rejectingOrderId) return;
+    if (!rejectReason.trim()) {
+      toast.error(t('form.provideReason'));
+      return;
+    }
+    setUpdatingId(rejectingOrderId);
+    try {
+      await api.patch(`/orders/${rejectingOrderId}/status`, {
+        status: 'CANCELLED',
+        cancellationReason: rejectReason.trim(),
+      });
+      setOrders(prev =>
+        prev.map(o => o.id === rejectingOrderId ? ({ ...o, status: 'CANCELLED' } as Order) : o)
+      );
+      toast.success(t('success.orderCancelled2'));
+      setShowRejectModal(false);
+      setRejectingOrderId(null);
+      setRejectReason('');
     } catch (error: unknown) {
       toast.error(getErrorMessage(error));
     } finally {
@@ -231,7 +260,7 @@ export default function StaffOrdersPage() {
                     )}
 
                     {/* Status update actions */}
-                    {nextStatuses.length > 0 && (
+                    {(nextStatuses.length > 0 || ['PENDING', 'ACCEPTED', 'PREPARING'].includes(order.status)) && (
                       <div>
                         <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">{t('orders2.updateStatus')}</p>
                         <div className="flex flex-wrap gap-2">
@@ -246,6 +275,19 @@ export default function StaffOrdersPage() {
                               {isUpdating ? t('orders2.updating') : `${t('orders2.markAs')} ${s.replace(/_/g, ' ').toLowerCase()}`}
                             </button>
                           ))}
+                          {['PENDING', 'ACCEPTED', 'PREPARING'].includes(order.status) && (
+                            <button
+                              onClick={() => {
+                                setRejectingOrderId(order.id);
+                                setRejectReason('');
+                                setShowRejectModal(true);
+                              }}
+                              disabled={isUpdating}
+                              className="px-4 py-2 rounded-xl text-sm font-medium text-white bg-red-500 hover:bg-red-600 transition-all disabled:opacity-50"
+                            >
+                              {t('orders2.rejectOrder', 'Reject / Cancel Order')}
+                            </button>
+                          )}
                         </div>
                       </div>
                     )}
@@ -254,6 +296,39 @@ export default function StaffOrdersPage() {
               </div>
             );
           })}
+        </div>
+      )}
+      {showRejectModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md">
+            <h3 className="text-lg font-bold text-gray-900 mb-3">{t('orders2.rejectOrder')}</h3>
+            <textarea
+              value={rejectReason}
+              onChange={e => setRejectReason(e.target.value)}
+              rows={4}
+              placeholder={t('checkout2.rejectReasonPlaceholder')}
+              className="w-full px-4 py-3 border-2 border-gray-300 rounded-xl text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent outline-none resize-none"
+            />
+            <div className="flex gap-3 mt-4">
+              <button
+                onClick={() => {
+                  setShowRejectModal(false);
+                  setRejectingOrderId(null);
+                  setRejectReason('');
+                }}
+                className="flex-1 py-2.5 border-2 border-gray-300 text-gray-700 rounded-lg text-sm font-medium"
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                onClick={handleRejectOrder}
+                disabled={!!updatingId || !rejectReason.trim()}
+                className="flex-1 py-2.5 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+              >
+                Confirm Rejection
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,7 @@ export interface Medication {
   quantity: number;
   pharmacy?: Pharmacy;
   branchId?: string;
+  branch?: Branch;
 }
 
 export interface OrderItem {


### PR DESCRIPTION
# Pull Request: Patient & Staff Order Management Enhancements

## Description

This PR introduces UI enhancements to the patient and staff portals for better order tracking and management, alongside a critical backend fix to support correct inventory restoration when staff cancels or rejects an order.

---

## What Was Wrong?

1. **Patient Order Detail Modal Lock**: 
   When a patient viewed their orders list at `/patient/orders` and clicked an order, a detailed dialog (`OrderDetailDialog`) would open up. However, the modal did not provide a way to navigate to the standalone order tracking page (`/patient/orders/[id]`). As a result, patients could not perform critical actions like completing payment (MTN MoMo, Airtel Money, Cards) or cancelling the order if needed.

2. **No Order Rejection/Cancellation for Pharmacy Staff**:
   On the staff orders board (`/staff/orders`), pharmacists and cashiers could only transition orders forward (e.g. from PENDING to ACCEPTED, PREPARING, etc.). There was no option to reject or cancel an order that could not be fulfilled.

3. **Backend Stock Leak on Staff Status Update Cancellation**:
   If an order status was changed to `CANCELLED` via the pharmacy status update endpoint (`PATCH /orders/:id/status`), the backend updated the database status but failed to release/restore the reserved medication stock count. This created inventory discrepancies compared to the patient-initiated cancellation endpoint which correctly restored the stock levels.

4. **Staff Dashboard Typo/Compilation Bug**:
   An initial integration had a scoping bug where the `isUpdating` spinner boolean was referenced outside of the map renderer loop, causing a TypeScript build failure.

---

## Proposed Changes

### 1. Frontend Enhancements (Primary)

#### **Patient Portal**
- **File modified**: [patient/orders/page.tsx](file:///c:/Users/Richter%20Richard%20NAHO/Desktop/E-Vz/E-vuze/pharmacy_front/src/app/patient/orders/page.tsx)
- **Changes**: Imported `Link` from `next/link` and updated `OrderDetailDialog`'s footer. Added a primary-styled **"Manage Order"** action button alongside the "Close" button. This navigates patients directly to `/patient/orders/${order.id}` where they can complete payment or cancel the order.

#### **Pharmacy / Staff Portal**
- **File modified**: [staff/orders/page.tsx](file:///c:/Users/Richter%20Richard%20NAHO/Desktop/E-Vz/E-vuze/pharmacy_front/src/app/staff/orders/page.tsx)
- **Changes**:
  - Introduced local state variables: `rejectingOrderId`, `rejectReason`, and `showRejectModal` to manage the cancellation process.
  - Implemented the `handleRejectOrder` handler which invokes a `PATCH /orders/:id/status` request payload mapping `status: 'CANCELLED'` and the inputted `cancellationReason`.
  - Added a red **"Reject / Cancel Order"** button in the list actions for any order in a `PENDING`, `ACCEPTED`, or `PREPARING` state.
  - Rendered a styled confirmation dialog modal prompting the staff member for the rejection reason.
  - Fixed the compilation issue by changing the Confirm button's `disabled` prop check to reference `!!updatingId` instead of the out-of-scope `isUpdating` boolean.

---

### 2. Supporting Backend Edits

#### **Backend Order Status Service**
- **File modified**: [orders.service.ts](file:///C:/Users/Richter%20Richard%20NAHO/Desktop/E-Vz/E-vuze/back-end/src/orders/orders.service.ts)
- **Changes**: Modified `updateStatus()` method to intercept a status change targeting `CANCELLED`. If the new status is `CANCELLED`, the system loops through all items in the order and triggers `this.medicationsService.restoreStock()` to return the reserved quantities to the pharmacy inventory.

---

## How to Verify

### Automated Verification
Run the TypeScript compiler to ensure there are no compilation or layout errors:
```bash
# Frontend
cd pharmacy_front
npx tsc --noEmit

# Backend
cd back-end
npx tsc --noEmit
```

### Manual Verification Flow
1. Log in as a patient, go to `/patient/orders`, click on a pending order to open the dialog, and verify that clicking **"Manage Order"** redirects you to `/patient/orders/[id]`.
2. Log in as a pharmacist/staff member, go to `/staff/orders`, and click on a PENDING or ACCEPTED order.
3. Click **"Reject / Cancel Order"**, enter a cancellation reason (e.g. "Out of stock"), and click **"Confirm Rejection"**.
4. Verify the order status updates to **CANCELLED** and the corresponding medication's stock quantity increases in the inventory database.
