### PR TITLE
Tita hospital foundation

### DIFF
--- a/src/app/hospital/doctor/patient/page.tsx
+++ b/src/app/hospital/doctor/patient/page.tsx
@@ -2,7 +2,7 @@ export default function HospitalDoctorRefusalsPage() {
   return (
     <div className="space-y-6">
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Refusals</h1>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Patients</h1>
         <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
       </div>
     </div>

--- a/src/app/hospital/doctor/prescription/page.tsx
+++ b/src/app/hospital/doctor/prescription/page.tsx
@@ -2,7 +2,7 @@ export default function HospitalDoctorClaimsPage() {
   return (
     <div className="space-y-6">
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Claims</h1>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Prescriptions</h1>
         <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
       </div>
     </div>

--- a/src/app/hospital/doctor/settings/page.tsx
+++ b/src/app/hospital/doctor/settings/page.tsx
@@ -1,9 +1,246 @@
+'use client';
+
+import { useState } from 'react';
+import { Settings, CheckCircle, Pencil } from 'lucide-react';
+
+const NAVY     = '#1E3A5F';
+const TEAL     = '#38BDF8';
+const GRADIENT = 'linear-gradient(90deg, #0284C7 0%, #38BDF8 100%)';
+
+const mockDoctor = {
+  name:          'Dr. Charles Edwin',
+  initials:      'CE',
+  role:          'Doctor',
+  email:         'charlesedwin@gmail.com',
+  phone:         '+250789374753',
+  hospital:      'La crois de sud',
+  specialization:'Dentist',
+  licenseNumber: 'xxxx-xxxx-xxxx',
+  workingHours:  '10 AM - 5PM',
+  status:        'APPROVED' as const,
+};
+
+type Tab = 'profile' | 'department' | 'changePassword';
+
+/* shared input class — min 44px height, high-contrast label */
+const inputCls =
+  'w-full border border-gray-200 rounded-xl px-4 text-sm text-gray-700 outline-none ' +
+  'focus:ring-2 disabled:bg-white disabled:text-gray-600 transition-all ' +
+  'min-h-11';
+
+const labelCls = 'block text-xs font-bold text-gray-600 uppercase tracking-widest mb-2';
+
 export default function HospitalDoctorSettingsPage() {
+  const [activeTab,      setActiveTab]      = useState<Tab>('profile');
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [profileForm,    setProfileForm]    = useState({
+    fullName:       mockDoctor.name,
+    email:          mockDoctor.email,
+    phone:          mockDoctor.phone,
+    specialization: mockDoctor.specialization,
+  });
+  const [passwordForm, setPasswordForm] = useState({
+    current: '',
+    newPass: '',
+    confirm: '',
+  });
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'profile',        label: 'Profile' },
+    { key: 'department',     label: 'Department' },
+    { key: 'changePassword', label: 'Change Password' },
+  ];
+
   return (
-    <div className="space-y-6">
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Settings</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
+    <div className="space-y-8">
+
+      {/* ── Hero header ── */}
+      <div
+        className="rounded-2xl px-6 sm:px-10 py-8 sm:py-10 flex items-center justify-between"
+        style={{ background: '#EBF5FF' }}
+      >
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>Settings</h1>
+          <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+            Manage your account and preferences
+          </p>
+        </div>
+        <div className="relative opacity-20 shrink-0" style={{ color: NAVY }}>
+          <Settings size={72} />
+          <div className="absolute -bottom-1 -right-1 bg-white rounded-full p-1">
+            <Pencil size={20} style={{ color: NAVY }} />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Tabs — scrollable so "Change Password" never wraps ── */}
+      <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className="shrink-0 whitespace-nowrap px-5 py-2 rounded-full text-sm font-semibold transition-all min-h-[38px]"
+            style={
+              activeTab === tab.key
+                ? { background: GRADIENT, color: '#fff' }
+                : { background: '#fff', color: '#6b7280', border: '1px solid #d1d5db' }
+            }
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Body — stacks vertically on mobile, side-by-side on lg+ ── */}
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+
+        {/* Doctor card */}
+        <div className="w-full lg:w-72 lg:shrink-0 bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-7 flex flex-col items-center text-center">
+          <div
+            className="w-20 h-20 sm:w-24 sm:h-24 rounded-full flex items-center justify-center text-white text-2xl sm:text-3xl font-bold mb-4"
+            style={{ background: GRADIENT }}
+          >
+            {mockDoctor.initials}
+          </div>
+          <p className="font-bold text-base sm:text-lg" style={{ color: NAVY }}>{mockDoctor.name}</p>
+          <p className="text-sm text-gray-500 mt-0.5">{mockDoctor.role}</p>
+
+          <div className="w-full border-t border-gray-100 my-5" />
+
+          <div className="w-full text-left space-y-4">
+            {[
+              { label: 'Email',        value: mockDoctor.email,   extra: 'break-all' },
+              { label: 'Phone Number', value: mockDoctor.phone,   extra: '' },
+              { label: 'Hospital',     value: mockDoctor.hospital, teal: true },
+            ].map(({ label, value, extra, teal }) => (
+              <div key={label}>
+                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-0.5">{label}</p>
+                <p
+                  className={`text-sm ${extra} ${teal ? 'font-semibold' : 'text-gray-700'}`}
+                  style={teal ? { color: TEAL } : {}}
+                >
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 w-full space-y-6">
+
+          {/* PROFILE TAB */}
+          {activeTab === 'profile' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-base font-bold" style={{ color: NAVY }}>Profile Information</h2>
+                <button
+                  onClick={() => setEditingProfile(!editingProfile)}
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold text-white transition-all hover:opacity-90 min-h-11"
+                  style={{ background: GRADIENT }}
+                >
+                  <Pencil size={14} />
+                  {editingProfile ? 'Cancel' : 'Edit Profile'}
+                </button>
+              </div>
+
+              {/* 1-col on mobile, 2-col on sm+ */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+                {[
+                  { label: 'Full Name',      key: 'fullName'       as const },
+                  { label: 'Email',          key: 'email'          as const },
+                  { label: 'Phone Number',   key: 'phone'          as const },
+                  { label: 'Specialization', key: 'specialization' as const },
+                ].map(({ label, key }) => (
+                  <div key={key}>
+                    <label className={labelCls}>{label}</label>
+                    <input
+                      type="text"
+                      value={profileForm[key]}
+                      disabled={!editingProfile}
+                      onChange={(e) => setProfileForm((p) => ({ ...p, [key]: e.target.value }))}
+                      className={inputCls}
+                      style={{ '--tw-ring-color': TEAL } as React.CSSProperties}
+                    />
+                  </div>
+                ))}
+              </div>
+
+              {editingProfile && (
+                <div className="mt-6 flex justify-end">
+                  <button
+                    onClick={() => setEditingProfile(false)}
+                    className="w-full sm:w-auto px-8 min-h-11 rounded-xl text-white text-sm font-semibold hover:opacity-90 transition-all"
+                    style={{ background: GRADIENT }}
+                  >
+                    Save Changes
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* DEPARTMENT TAB */}
+          {activeTab === 'department' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-base font-bold" style={{ color: NAVY }}>Department Details</h2>
+                <span className="flex items-center gap-1.5 text-sm font-semibold text-emerald-600">
+                  <CheckCircle size={15} />
+                  APPROVED
+                </span>
+              </div>
+              <div className="space-y-5">
+                {[
+                  { label: 'Specialization', value: mockDoctor.specialization },
+                  { label: 'License number', value: mockDoctor.licenseNumber },
+                  { label: 'Hospital',       value: mockDoctor.hospital },
+                  { label: 'Working hours',  value: mockDoctor.workingHours },
+                ].map(({ label, value }) => (
+                  <div key={label} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-6 text-sm">
+                    <span className="sm:w-40 text-gray-500 font-medium shrink-0">{label}</span>
+                    <span className="font-semibold text-gray-800">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* CHANGE PASSWORD TAB */}
+          {activeTab === 'changePassword' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <h2 className="text-base font-bold mb-6" style={{ color: NAVY }}>Change Password</h2>
+              <div className="space-y-5">
+                {[
+                  { label: 'Current Password',    key: 'current' as const },
+                  { label: 'New Password',         key: 'newPass' as const },
+                  { label: 'Confirm New Password', key: 'confirm' as const },
+                ].map(({ label, key }) => (
+                  <div key={key}>
+                    <label className={labelCls}>{label}</label>
+                    <input
+                      type="password"
+                      value={passwordForm[key]}
+                      onChange={(e) => setPasswordForm((p) => ({ ...p, [key]: e.target.value }))}
+                      className={inputCls}
+                      style={{ '--tw-ring-color': TEAL } as React.CSSProperties}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="mt-7">
+                {/* Full-width on mobile, auto-width on sm+ */}
+                <button
+                  className="w-full sm:w-auto sm:px-10 min-h-11 rounded-xl text-white text-sm font-semibold hover:opacity-90 transition-all"
+                  style={{ background: GRADIENT }}
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          )}
+
+        </div>
       </div>
     </div>
   );

--- a/src/components/hospital/HospitalSidebar.tsx
+++ b/src/components/hospital/HospitalSidebar.tsx
@@ -6,14 +6,12 @@ import {
   LayoutDashboard,
   CalendarDays,
   ClipboardList,
-  XCircle,
+  Users,
   Clock,
   MessageSquare,
-  FileText,
-  Package,
+  Pill,
   Settings,
   DollarSign,
-  Users,
   Building2,
   BarChart2,
   LogOut,
@@ -21,17 +19,16 @@ import {
 } from 'lucide-react';
 
 const NAVY = '#1E3A5F';
-const TEAL = '#2D9B8A';
+const TEAL = '#38BDF8';
 
 const DOCTOR_NAV = [
   { href: '/hospital/doctor/dashboard',     icon: LayoutDashboard, label: 'Dashboard' },
   { href: '/hospital/doctor/appointments',  icon: CalendarDays,    label: 'Appointments' },
   { href: '/hospital/doctor/consultations', icon: ClipboardList,   label: 'Consultations' },
-  { href: '/hospital/doctor/refusals',      icon: XCircle,         label: 'Refusals' },
+  { href: '/hospital/doctor/patient',       icon: Users,           label: 'Patients' },
   { href: '/hospital/doctor/schedule',      icon: Clock,           label: 'Schedule' },
   { href: '/hospital/doctor/messages',      icon: MessageSquare,   label: 'Messages' },
-  { href: '/hospital/doctor/claims',        icon: FileText,        label: 'Claims' },
-  { href: '/hospital/doctor/inventory',     icon: Package,         label: 'Inventory' },
+  { href: '/hospital/doctor/prescription',  icon: Pill,            label: 'Prescriptions' },
   { href: '/hospital/doctor/settings',      icon: Settings,        label: 'Settings' },
 ];
 

--- a/src/components/hospital/HospitalTopbar.tsx
+++ b/src/components/hospital/HospitalTopbar.tsx
@@ -28,21 +28,23 @@ export default function HospitalTopbar({ userName, roleLabel, hospitalName, onMe
 
   return (
     <header className="sticky top-0 z-30 h-16 bg-white border-b border-gray-200 flex items-center justify-between px-4 lg:px-6">
-      <div className="flex items-center gap-3">
+      {/* Left: menu + hospital name */}
+      <div className="flex items-center gap-3 min-w-0 flex-1">
         <button
           onClick={onMenuClick}
-          className="lg:hidden p-2 rounded-lg hover:bg-gray-100 transition-colors"
+          className="lg:hidden p-2 rounded-lg hover:bg-gray-100 transition-colors shrink-0"
           aria-label="Open sidebar"
         >
           <Menu size={18} className="text-gray-600" />
         </button>
-        <div>
-          <p className="text-base font-semibold" style={{ color: '#1E3A5F' }}>{hospitalName}</p>
+        <div className="min-w-0">
+          <p className="text-base font-semibold truncate" style={{ color: '#1E3A5F' }}>{hospitalName}</p>
           <p className="text-xs text-gray-500 hidden sm:block">{roleLabel}</p>
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
+      {/* Right: langs + bell + avatar — shrink-0 so it never gets squeezed */}
+      <div className="flex items-center gap-3 shrink-0 ml-3">
         <div className="hidden md:flex items-center gap-1">
           {SUPPORTED_LANGUAGES.map((lang, i) => (
             <span key={lang.code} className="flex items-center">
@@ -57,13 +59,13 @@ export default function HospitalTopbar({ userName, roleLabel, hospitalName, onMe
           ))}
         </div>
 
-        <button className="relative p-2 rounded-full hover:bg-gray-100" aria-label="Notifications">
+        <button className="relative p-2 rounded-full hover:bg-gray-100 shrink-0" aria-label="Notifications">
           <Bell size={18} className="text-gray-600" />
         </button>
 
         <div className="flex items-center gap-2">
           <div
-            className="w-9 h-9 rounded-full flex items-center justify-center text-white text-sm font-semibold"
+            className="w-9 h-9 rounded-full flex items-center justify-center text-white text-sm font-semibold shrink-0"
             style={{ backgroundColor: '#2D9B8A' }}
           >
             {initials}


### PR DESCRIPTION
## What this PR does

Implements the Doctor Settings page with full mobile responsiveness, updates the
Hospital Doctor sidebar navigation, and hardens the top-bar layout for small screens.

---

## Pages built / changed

| Route | Work done |
|---|---|
| `/hospital/doctor/settings` | Full settings page Profile, Department, and Change Password tabs with mock data |
| `HospitalSidebar` (doctor) | Nav updated: Refusals → Patients, Inventory → Prescriptions; icons and routes corrected |
| `HospitalTopbar` | Mobile header fixed  hospital name truncates, right section stays pinned to corner |

---

## Files changed

| File | Change |
|---|---|
| `src/app/hospital/doctor/settings/page.tsx` | New settings page (Profile / Department / Change Password tabs, mock doctor data, gradient buttons) |
| `src/components/hospital/HospitalSidebar.tsx` | Doctor nav: replaced `XCircle`/`Package` with `Users`/`Pill`; fixed `/patient` and `/prescription` routes; active color → `#38BDF8` |
| `src/components/hospital/HospitalTopbar.tsx` | Left section: `flex-1 min-w-0` + `truncate`; right section: `shrink-0`; avatar and bell: `shrink-0` |

---

## Mock data used

`src/app/hospital/doctor/settings/page.tsx`  inline `mockDoctor` object:
`name`, `initials`, `role`, `email`, `phone`, `hospital`, `specialization`,
`licenseNumber`, `workingHours`, `status`

---

## Visual / design changes

- Settings hero: gear + pencil composite icon matching phone settings app style
- All buttons/interactive elements (outside hero): `linear-gradient(90deg, #0284C7 0%, #38BDF8 100%)`
- Sidebar active state: flat `#38BDF8`

---

## Mobile fixes (Settings page)

1. **Layout**  `flex-col` on mobile, `lg:flex-row` on desktop; doctor card goes full-width then stacks above tab content
2. **Tab bar** `overflow-x-auto` + `whitespace-nowrap` prevents "Change Password" from wrapping
3. **Tap targets**  all inputs and buttons `min-h-11` (44 px)
4. **Label contrast**  labels upgraded from `text-gray-400` to `text-gray-600` (WCAG AA)
5. **Card separation**  `border border-gray-100 shadow-md` on every card

---

## Test steps

- `/hospital/doctor/settings` → Profile tab shows mock doctor data; Edit Profile toggles
  inputs; Department tab shows APPROVED badge; Change Password tab  Confirm button is
  full-width on mobile
- Sidebar → clicking Prescriptions and Patients routes correctly (no 404)
- Mobile viewport (< 640 px) → header avatar stays pinned right; settings cards stack
  vertically; tab bar scrolls without wrapping
- `npm run build` passes with 0 TypeScript errors
