### PR TITLE
Fix profile documents view

### DIFF
--- a/src/app/branch/staff/new/page.tsx
+++ b/src/app/branch/staff/new/page.tsx
@@ -178,7 +178,7 @@ export default function NewStaffPage() {
           </div>
           <div className="col-span-2">
             <label htmlFor="dateOfBirth" className="block text-xs font-semibold text-gray-700 mb-1">{t('form.dateOfBirth')}</label>
-            <input id="dateOfBirth" type="date" value={form.dateOfBirth} onChange={e => setForm(p => ({...p, dateOfBirth: e.target.value}))}
+            <input id="dateOfBirth" type="date" value={form.dateOfBirth} max={new Date().toISOString().split('T')[0]} onChange={e => setForm(p => ({...p, dateOfBirth: e.target.value}))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-emerald-500 outline-none" />
           </div>
         </div>

--- a/src/app/patient/profile/page.tsx
+++ b/src/app/patient/profile/page.tsx
@@ -136,7 +136,7 @@ export default function PatientProfilePage() {
           </div>
           <div>
             <label className="block text-xs font-semibold text-gray-600 mb-1">{t('profile2.dateOfBirth')}</label>
-            <input type="date" value={profile.dateOfBirth} onChange={e => setProfile({...profile, dateOfBirth: e.target.value})} className={inputCls} />
+            <input type="date" value={profile.dateOfBirth} max={new Date().toISOString().split('T')[0]} onChange={e => setProfile({...profile, dateOfBirth: e.target.value})} className={inputCls} />
           </div>
           <div>
             <label className="block text-xs font-semibold text-gray-600 mb-1">{t('profile2.gender')}</label>

--- a/src/app/pharmacy/profile/page.tsx
+++ b/src/app/pharmacy/profile/page.tsx
@@ -137,10 +137,10 @@ export default function PharmacyProfilePage() {
   ];
 
   const docs = [
-    { label: t('pharmacyOwner.pharmacyLicense'), date: 'January 10, 2025' },
-    { label: t('pharmacyOwner.nationalId'), date: 'January 6, 2018' },
-    { label: t('pharmacyOwner.taxRegistration'), date: 'January 6, 2018' },
-  ];
+    profile?.pharmacyLicense ? { label: t('pharmacyOwner.pharmacyLicense'), value: profile.pharmacyLicense } : null,
+    profile?.rdbCertificate  ? { label: t('pharmacyOwner.nationalId'),       value: profile.rdbCertificate  } : null,
+    profile?.businessRegistration ? { label: t('pharmacyOwner.taxRegistration'), value: profile.businessRegistration } : null,
+  ].filter(Boolean) as { label: string; value: string }[];
 
   return (
     <div className="space-y-6">
@@ -344,6 +344,9 @@ export default function PharmacyProfilePage() {
       <div className="bg-white rounded-2xl p-6 border border-gray-100">
         <h3 className="font-semibold text-gray-900 mb-4">{t('pharmacyOwner.submittedDocuments')}</h3>
         <div className="space-y-3">
+          {docs.length === 0 && (
+            <p className="text-sm text-gray-400 py-2">{t('staffPages.noDocOnFile')}</p>
+          )}
           {docs.map(doc => (
             <div
               key={doc.label}
@@ -357,17 +360,10 @@ export default function PharmacyProfilePage() {
                   <DocumentTextIcon className="w-[18px] h-[18px] text-brand-navy" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-800">{doc.label}</p>
-                  <p className="text-xs text-gray-400">
-                    {t('pharmacyOwner.uploaded')}: {doc.date}
-                  </p>
+                  <p className="text-xs text-gray-400 font-medium">{doc.label}</p>
+                  <p className="text-sm font-semibold text-gray-800 mt-0.5">{doc.value}</p>
                 </div>
               </div>
-              <button
-                className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg border border-brand-navy text-brand-navy text-sm font-medium hover:bg-blue-50 transition-colors"
-              >
-                {t('common.view')}
-              </button>
             </div>
           ))}
         </div>

--- a/src/app/pharmacy/profile/page.tsx
+++ b/src/app/pharmacy/profile/page.tsx
@@ -139,7 +139,6 @@ export default function PharmacyProfilePage() {
   const docs = [
     profile?.pharmacyLicense ? { label: t('pharmacyOwner.pharmacyLicense'), value: profile.pharmacyLicense } : null,
     profile?.rdbCertificate  ? { label: t('pharmacyOwner.nationalId'),       value: profile.rdbCertificate  } : null,
-    profile?.businessRegistration ? { label: t('pharmacyOwner.taxRegistration'), value: profile.businessRegistration } : null,
   ].filter(Boolean) as { label: string; value: string }[];
 
   return (

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -228,6 +228,7 @@ export default function SignupPage() {
                 <div>
                   <label className={labelCls}>{t('signup.dateOfBirth')}</label>
                   <input type="date" required value={patientForm.dateOfBirth}
+                    max={new Date().toISOString().split('T')[0]}
                     onChange={e => setPatientForm({...patientForm, dateOfBirth: e.target.value})}
                     className={inputCls.replace('pl-11','pl-3')} />
                 </div>

--- a/src/app/staff/profile/page.tsx
+++ b/src/app/staff/profile/page.tsx
@@ -19,6 +19,7 @@ import {
   LockClosedIcon,
   ShieldCheckIcon,
 } from '@heroicons/react/24/outline';
+import { openFile } from '@/lib/openFile';
 
 interface StaffProfile {
   id: string;
@@ -140,23 +141,23 @@ export default function StaffProfilePage() {
   const roleLabel   = profile.user.role.charAt(0) + profile.user.role.slice(1).toLowerCase();
 
   const documents = [
-    {
+    profile.licenseUrl ? {
       label:  t('staffPages.pharmacistLicense'),
       expiry: profile.licenseExpiry
         ? `${t('staffPages.docExpires')} ${new Date(profile.licenseExpiry).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
         : `${t('staffPages.docExpires')} —`,
-      url:  profile.licenseUrl ?? null,
+      url:  profile.licenseUrl,
       icon: DocumentTextIcon,
-    },
-    {
+    } : null,
+    profile.nationalId ? {
       label:  t('staffPages.nationalIdCert'),
       expiry: profile.nationalIdExpiry
         ? `${t('staffPages.docExpired')} ${new Date(profile.nationalIdExpiry).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
-        : profile.nationalId ? `${t('staffPages.docIdPrefix')} ${profile.nationalId}` : t('staffPages.noDocOnFile'),
+        : `${t('staffPages.docIdPrefix')} ${profile.nationalId}`,
       url:  null,
       icon: PhotoIcon,
-    },
-  ];
+    } : null,
+  ].filter(Boolean) as { label: string; expiry: string; url: string | null; icon: React.ComponentType<{ className?: string }> }[];
 
   return (
     <div className="max-w-6xl mx-auto space-y-5 p-4 lg:p-6">
@@ -312,6 +313,9 @@ export default function StaffProfilePage() {
             <h2 className="font-bold text-gray-900 text-base mb-4">{t('pharmacyOwner.submittedDocuments')}</h2>
 
             <div className="space-y-3">
+              {documents.length === 0 && (
+                <p className="text-sm text-gray-400 py-2">{t('staffPages.noDocOnFile')}</p>
+              )}
               {documents.map(({ label, expiry, url, icon: Icon }) => (
                 <div key={label} className="flex items-center justify-between p-3 rounded-xl border border-gray-100 bg-gray-50/50">
                   <div className="flex items-center gap-3">
@@ -323,21 +327,15 @@ export default function StaffProfilePage() {
                       <p className="text-xs text-gray-400 mt-0.5">{expiry}</p>
                     </div>
                   </div>
-                  {url ? (
-                    <a
-                      href={url}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                  {url && (
+                    <button
+                      type="button"
+                      onClick={() => openFile(url)}
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-blue-200 text-blue-500 text-xs font-semibold hover:bg-blue-50 transition-colors"
                     >
                       <EyeIcon className="w-3.5 h-3.5" />
                       {t('common.view')}
-                    </a>
-                  ) : (
-                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 text-gray-400 text-xs font-semibold">
-                      <EyeIcon className="w-3.5 h-3.5" />
-                      {t('common.view')}
-                    </span>
+                    </button>
                   )}
                 </div>
               ))}

--- a/src/lib/openFile.ts
+++ b/src/lib/openFile.ts
@@ -1,0 +1,20 @@
+// Converts a data URI to a temporary blob URL and opens it in a new tab.
+// Needed because Safari blocks navigation to data: URIs in new tabs.
+export function openFile(url: string): void {
+  if (!url.startsWith('data:')) {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    return;
+  }
+
+  const [header, base64] = url.split(',');
+  const mime = header.replace('data:', '').replace(';base64', '');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+  const blob = new Blob([bytes], { type: mime });
+  const blobUrl = URL.createObjectURL(blob);
+  const win = window.open(blobUrl, '_blank', 'noopener,noreferrer');
+  // Revoke after the tab has had time to load
+  if (win) win.addEventListener('load', () => URL.revokeObjectURL(blobUrl), { once: true });
+}


### PR DESCRIPTION
## Summary
This PR filters out phantom document rows on staff and pharmacy owner profile pages when no file has been uploaded, replaces unclickable View buttons with a functional `openFile()` helper, and blocks future dates in all date of birth fields.

## Changes
- Filtered document rows so only documents with an actual uploaded file are displayed (previously every user saw phantom rows regardless of upload status)
- Replaced unclickable gray `<span>` View buttons with a functional `openFile()` helper that opens files via a blob URL (Safari-compatible, avoids `data:` URI blocking)
- Pharmacy owner certificate numbers (`pharmacyLicense`, `rdbCertificate`) now render as read-only text since they are plain strings, not files
- Added `max={today}` constraint to all date of birth fields across signup, patient profile, and staff creation forms to block future date selection

## Affected portals / areas
- [x] Patient
- [x] Pharmacy
- [x] Branch
- [x] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting

## How to test
1. Log in as **Staff**, go to Profile, scroll to Submitted Documents: only rows for documents actually on file should appear; clicking **View** opens the file
2. Log in as **Pharmacy Owner** , then go to Profile, and scroll to Submitted Documents: certificate numbers display as read-only text with no broken View button
3. Open any signup or profile form with a **Date of Birth** field: future dates should be unselectable in the date picker

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [ ] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->