### PR TITLE
Fix cashier payment confirmation

### DIFF
--- a/src/app/branch/staff/new/page.tsx
+++ b/src/app/branch/staff/new/page.tsx
@@ -178,7 +178,7 @@ export default function NewStaffPage() {
           </div>
           <div className="col-span-2">
             <label htmlFor="dateOfBirth" className="block text-xs font-semibold text-gray-700 mb-1">{t('form.dateOfBirth')}</label>
-            <input id="dateOfBirth" type="date" value={form.dateOfBirth} onChange={e => setForm(p => ({...p, dateOfBirth: e.target.value}))}
+            <input id="dateOfBirth" type="date" value={form.dateOfBirth} max={new Date().toISOString().split('T')[0]} onChange={e => setForm(p => ({...p, dateOfBirth: e.target.value}))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-emerald-500 outline-none" />
           </div>
         </div>

--- a/src/app/patient/profile/page.tsx
+++ b/src/app/patient/profile/page.tsx
@@ -136,7 +136,7 @@ export default function PatientProfilePage() {
           </div>
           <div>
             <label className="block text-xs font-semibold text-gray-600 mb-1">{t('profile2.dateOfBirth')}</label>
-            <input type="date" value={profile.dateOfBirth} onChange={e => setProfile({...profile, dateOfBirth: e.target.value})} className={inputCls} />
+            <input type="date" value={profile.dateOfBirth} max={new Date().toISOString().split('T')[0]} onChange={e => setProfile({...profile, dateOfBirth: e.target.value})} className={inputCls} />
           </div>
           <div>
             <label className="block text-xs font-semibold text-gray-600 mb-1">{t('profile2.gender')}</label>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -228,6 +228,7 @@ export default function SignupPage() {
                 <div>
                   <label className={labelCls}>{t('signup.dateOfBirth')}</label>
                   <input type="date" required value={patientForm.dateOfBirth}
+                    max={new Date().toISOString().split('T')[0]}
                     onChange={e => setPatientForm({...patientForm, dateOfBirth: e.target.value})}
                     className={inputCls.replace('pl-11','pl-3')} />
                 </div>

--- a/src/components/staff/CashierPOSModal.tsx
+++ b/src/components/staff/CashierPOSModal.tsx
@@ -60,6 +60,7 @@ export default function CashierPOSModal({
 
   const [tab, setTab] = useState<'verify' | 'record'>('verify');
   const [verifyStatus, setVerifyStatus] = useState<'idle' | 'loading' | 'confirmed'>('idle');
+  const [confirming, setConfirming] = useState(false);
 
   const [method, setMethod] = useState<PaymentMethod>('cash');
   const [amountReceived, setAmountReceived] = useState('');
@@ -86,6 +87,7 @@ export default function CashierPOSModal({
         setNotes('');
         setSubmitting(false);
         setReceipt(null);
+        setConfirming(false);
       }, 200);
       return () => clearTimeout(timer);
     } else if (order) {
@@ -220,7 +222,66 @@ export default function CashierPOSModal({
         </div>
 
         <div className="p-6">
-          {receipt ? (
+          {confirming && !receipt ? (
+            /* ── Confirmation step ── */
+            <div className="space-y-5">
+              <div className="flex flex-col items-center text-center py-2">
+                <div className="h-12 w-12 rounded-full flex items-center justify-center mb-3 bg-amber-50">
+                  <BanknotesIcon className="w-6 h-6 text-amber-500" />
+                </div>
+                <h3 className="text-base font-semibold text-gray-900">{t('cashier.confirmPaymentTitle', 'Confirm Payment')}</h3>
+                <p className="text-sm text-gray-400 mt-0.5">{t('cashier.confirmPaymentSubtitle', 'Please review the details before processing.')}</p>
+              </div>
+
+              <div className="rounded-xl border border-gray-100 bg-gray-50 p-4 space-y-2.5 text-sm">
+                {[
+                  [t('cashier.totalDue'),       fmt(totalDue)],
+                  [t('cashier.paymentMethod'),  t(`cashier.method_${method}`)],
+                  ...(method === 'cash'
+                    ? [[t('cashier.amountReceived'), fmt(Number(amountReceived))],
+                       [t('cashier.change'),         fmt(change)]]
+                    : []),
+                  ...(method === 'mtn_momo' || method === 'airtel_money'
+                    ? [[t('cashier.phoneNumber') || 'Phone', phoneNumber]]
+                    : []),
+                  ...(method === 'insurance'
+                    ? [[t('cashier.insuranceProvider'), insuranceProvider],
+                       [t('cashier.policyNumber'),      policyNumber]]
+                    : []),
+                  ...(reference ? [[t('cashier.referenceNumber'), reference]] : []),
+                  [t('cashier.cashierLabel'),   cashierName],
+                ].map(([label, value], i) => (
+                  <div key={i} className="flex justify-between">
+                    <span className="text-gray-400">{label}</span>
+                    <span className="font-medium text-gray-900">{value}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setConfirming(false)}
+                  className="flex-1 py-3 rounded-xl border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                  {t('common.back', 'Back')}
+                </button>
+                <button
+                  onClick={handleRecord}
+                  disabled={submitting}
+                  className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl text-white text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50 bg-brand-teal"
+                >
+                  {submitting ? (
+                    <>
+                      <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                      {t('cashier.processing')}
+                    </>
+                  ) : (
+                    t('cashier.processPayment')
+                  )}
+                </button>
+              </div>
+            </div>
+          ) : receipt ? (
             /* Receipt screen */
             <div className="space-y-5">
               <div className="flex flex-col items-center text-center py-4">
@@ -445,18 +506,11 @@ export default function CashierPOSModal({
                   </div>
 
                   <button
-                    onClick={handleRecord}
-                    disabled={!canConfirmRecord || submitting}
+                    onClick={() => setConfirming(true)}
+                    disabled={!canConfirmRecord}
                     className="w-full flex items-center justify-center gap-2 py-3 rounded-xl text-white font-medium transition-opacity hover:opacity-90 disabled:opacity-50 bg-brand-teal"
                   >
-                    {submitting ? (
-                      <>
-                        <ArrowPathIcon className="w-4 h-4 animate-spin" />
-                        {t('cashier.processing')}
-                      </>
-                    ) : (
-                      t('cashier.confirmPayment')
-                    )}
+                    {t('cashier.confirmPayment')}
                   </button>
                 </div>
               )}


### PR DESCRIPTION
## Summary
This PR adds a confirmation screen to the cashier POS modal before any payment is processed. The cashier reviews a full summary of the transaction and must explicitly confirm before the API is called, preventing accidental submissions.

## Changes
- Added a confirmation screen between the payment form and the receipt screen in the cashier POS modal
- Confirmation screen displays a summary card with amount, payment method, change, phone/insurance details, and cashier name
- **Confirm Payment** advances to the confirmation screen; **Process Payment** hits the API; **Back** returns to the form with all fields intact

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [x] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting

## How to test
1. Log in as a **Cashier**
2. Open an order in the **Pending Payment** tab, then click **Process Payment** on a pending payment order
3. Switch to the **Record** tab, fill in payment details, click **Confirm Payment**
4. Verify the confirmation screen appears with the correct transaction summary
5. Click **Back**, then verify you return to the form with all fields intact
6. Click **Process Payment** and then verify the receipt screen appears as expected

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->