### PR TITLE
fix: password validation on branch manager and staff

### DIFF
--- a/src/app/branch/change-password/page.tsx
+++ b/src/app/branch/change-password/page.tsx
@@ -20,7 +20,7 @@ export default function BranchChangePasswordPage() {
     confirm: false,
   });
   const [form, setForm] = useState({
-    tempPassword: '',
+    currentPassword: '',
     newPassword: '',
     confirmPassword: '',
   });
@@ -28,20 +28,26 @@ export default function BranchChangePasswordPage() {
   const toggle = (field: keyof typeof showPass) =>
     setShowPass(prev => ({ ...prev, [field]: !prev[field] }));
 
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[\d@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,}$/;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (form.newPassword !== form.confirmPassword) {
-      toast.error(t('form.passwordsDoNotMatch'));
-      return;
-    }
     if (form.newPassword.length < 8) {
       toast.error(t('form.passwordTooShort'));
       return;
     }
+    if (!passwordRegex.test(form.newPassword)) {
+      toast.error('Password must contain uppercase, lowercase, and a number or special character (@$!%*?&#)');
+      return;
+    }
+    if (form.newPassword !== form.confirmPassword) {
+      toast.error(t('form.passwordsDoNotMatch'));
+      return;
+    }
     setLoading(true);
     try {
-      await api.put('/auth/branch/change-password', {
-        tempPassword: form.tempPassword,
+      await api.put('/auth/change-password', {
+        currentPassword: form.currentPassword,
         newPassword: form.newPassword,
         confirmPassword: form.confirmPassword,
       });
@@ -85,9 +91,9 @@ export default function BranchChangePasswordPage() {
               <input
                 type={showPass.current ? 'text' : 'password'}
                 required
-                value={form.tempPassword}
+                value={form.currentPassword}
                 onChange={e =>
-                  setForm(p => ({ ...p, tempPassword: e.target.value }))
+                  setForm(p => ({ ...p, currentPassword: e.target.value }))
                 }
                 placeholder="Enter current password"
                 className="w-full px-4 py-3.5 pr-11 border border-gray-200 rounded-xl text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#1E3A5F]/30 focus:border-[#1E3A5F] transition"
@@ -115,12 +121,11 @@ export default function BranchChangePasswordPage() {
               <input
                 type={showPass.new ? 'text' : 'password'}
                 required
-                minLength={8}
                 value={form.newPassword}
                 onChange={e =>
                   setForm(p => ({ ...p, newPassword: e.target.value }))
                 }
-                placeholder="At least 8 characters"
+                placeholder="Min 8 chars, uppercase, number, special char"
                 className="w-full px-4 py-3.5 pr-11 border border-gray-200 rounded-xl text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#1E3A5F]/30 focus:border-[#1E3A5F] transition"
               />
               <button
@@ -136,6 +141,10 @@ export default function BranchChangePasswordPage() {
               </button>
             </div>
           </div>
+
+          <p className="text-xs text-gray-400 -mt-4">
+            8+ characters with uppercase, lowercase, and a number or special character (@$!%*?&#)
+          </p>
 
           {/* Confirm New Password */}
           <div>

--- a/src/app/staff/change-password/page.tsx
+++ b/src/app/staff/change-password/page.tsx
@@ -12,27 +12,33 @@ export default function StaffChangePasswordPage() {
   const { t } = useTranslation();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [showPass, setShowPass] = useState({ temp: false, new: false, confirm: false });
+  const [showPass, setShowPass] = useState({ current: false, new: false, confirm: false });
   const [form, setForm] = useState({
-    tempPassword: '',
+    currentPassword: '',
     newPassword: '',
     confirmPassword: '',
   });
 
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[\d@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,}$/;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (form.newPassword !== form.confirmPassword) {
-      toast.error(t('form.passwordsDoNotMatch'));
-      return;
-    }
     if (form.newPassword.length < 8) {
       toast.error(t('form.passwordTooShort'));
       return;
     }
+    if (!passwordRegex.test(form.newPassword)) {
+      toast.error('Password must contain uppercase, lowercase, and a number or special character (@$!%*?&#)');
+      return;
+    }
+    if (form.newPassword !== form.confirmPassword) {
+      toast.error(t('form.passwordsDoNotMatch'));
+      return;
+    }
     setLoading(true);
     try {
-      await api.put('/staff/profile/change-password', {
-        tempPassword: form.tempPassword,
+      await api.put('/auth/change-password', {
+        currentPassword: form.currentPassword,
         newPassword: form.newPassword,
         confirmPassword: form.confirmPassword,
       });
@@ -64,9 +70,9 @@ export default function StaffChangePasswordPage() {
 
           <form onSubmit={handleSubmit} className="space-y-4">
             {[
-              { field: 'temp' as const,    label: t('staff.tempPassword'),    key: 'tempPassword',    placeholder: t('staff.tempPasswordPlaceholder') },
-              { field: 'new' as const,     label: t('staff.newPassword'),     key: 'newPassword',     placeholder: t('staff.newPasswordPlaceholder') },
-              { field: 'confirm' as const, label: t('staff.confirmPassword'), key: 'confirmPassword', placeholder: t('staff.confirmPasswordPlaceholder') },
+              { field: 'current' as const, label: 'Current Password',          key: 'currentPassword', placeholder: t('staff.tempPasswordPlaceholder') },
+              { field: 'new' as const,     label: t('staff.newPassword'),       key: 'newPassword',     placeholder: t('staff.newPasswordPlaceholder') },
+              { field: 'confirm' as const, label: t('staff.confirmPassword'),   key: 'confirmPassword', placeholder: t('staff.confirmPasswordPlaceholder') },
             ].map(({ field, label, key, placeholder }) => (
               <div key={key}>
                 <label className="block text-xs font-semibold text-gray-700 mb-1">{label}</label>
@@ -87,6 +93,11 @@ export default function StaffChangePasswordPage() {
                     {showPass[field] ? <EyeSlashIcon className="w-4 h-4" /> : <EyeIcon className="w-4 h-4" />}
                   </button>
                 </div>
+                {key === 'newPassword' && (
+                  <p className="text-xs text-gray-400 mt-1">
+                    8+ characters with uppercase, lowercase, and a number or special character (@$!%*?&#)
+                  </p>
+                )}
               </div>
             ))}
 


### PR DESCRIPTION
## Summary
This PR addresses the issue of password validation on both branch manager and staff change-password pages to mirror backend requirements, and switched to the correct `PUT /auth/change-password` endpoint to fix a 500 crash caused by `tempPasswordHash` being null after first-time setup.

## Changes
- Fixed password validation regex on branch manager and staff change-password pages to correctly require uppercase + lowercase + number or special character
- Switched both pages from `/auth/branch/change-password` and `/staff/profile/change-password` to the general `PUT /auth/change-password` endpoint, which validates against the user's current live password
- Removed browser-native `minLength` attribute that was triggering inconsistent validation — validation is now purely JS-driven with clear toast error messages
- Added password requirement hint text below the New Password field on both pages

## Root cause
The old endpoints required `tempPasswordHash` to exist in the database, which is cleared to `null` after first-time setup. Any subsequent password change attempt crashed the backend with a 500 error. The general `PUT /auth/change-password` endpoint uses the user's current login password, making it work for both first-time and subsequent changes.

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [x] Branch
- [x] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting

## How to test
1. Log in as a **Branch Manager** → Settings → Change Password
   - Enter current password and a valid new password → confirm successful change and redirect to dashboard
   - Enter a password missing uppercase, lowercase, or number/special char → confirm toast error appears before API is called
   - Enter mismatched confirm password → confirm it is caught before the API call
2. Repeat all steps above logged in as **Pharmacist** or **Cashier** 

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->