### PR TITLE
fix: add the missing branch column

### DIFF
--- a/src/app/pharmacy/inventory/page.tsx
+++ b/src/app/pharmacy/inventory/page.tsx
@@ -155,7 +155,7 @@ useEffect(() => {
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
-                {['Medication Name','Category','Dosage','Manufacturer','Unit Price','Qty in Stock','Threshold','Prescription','Expiry','Status','Actions'].map(h => (
+                {['Medication Name','Branch','Category','Dosage','Manufacturer','Unit Price','Qty in Stock','Threshold','Prescription','Expiry','Status','Actions'].map(h => (
                     <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide whitespace-nowrap">{h}</th>
                 ))}
                 </tr>
@@ -170,6 +170,12 @@ useEffect(() => {
                       <p className="font-semibold text-gray-900">{med.name}</p>
                       {med.description && <p className="text-xs text-gray-400 truncate max-w-[140px]">{med.description}</p>}
                       </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {med.branch?.name
+                        ? <span className="inline-block px-2 py-0.5 bg-indigo-50 text-indigo-700 text-xs font-medium rounded-full">{med.branch.name}</span>
+                        : <span className="text-gray-400 text-xs">—</span>
+                      }
+                    </td>
                     <td className="px-4 py-3">
                       <span className="inline-block px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded-full whitespace-nowrap">{med.category}</span>
                     </td>


### PR DESCRIPTION
## Summary
This PR fixes the issue of missing Branch column by adding it to the pharmacy owner inventory table so medications can be identified by which branch they belong to. No new API calls were needed as `branch.name` was already included in the existing response.

## Changes
- Added a Branch column to the inventory table after the Medication Name column
- Medications assigned to a branch display an indigo badge with the branch name
- Medications not linked to a branch display (as a fallback)

## Affected portals / areas
- [ ] Patient
- [x] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting

## How to test
1. Log in as a **Pharmacy Owner**, then go to Inventory
2. Verify the **Branch** column appears after Medication Name
3. Verify medications linked to a branch show the branch name as an indigo badge
4. Verify medications not linked to a branch

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->