### PR TITLE
feat: implementing reports and analytics page

### DIFF
--- a/src/app/hospital/admin/reports/page.tsx
+++ b/src/app/hospital/admin/reports/page.tsx
@@ -1,9 +1,171 @@
-export default function HospitalAdminReportsPage() {
+'use client';
+
+import { useState } from 'react';
+import { ClipboardDocumentListIcon } from '@heroicons/react/24/outline';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend,
+  PieChart, Pie,
+  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
+} from 'recharts';
+import {
+  MOCK_WAIT_TIMES,
+  MOCK_PATIENT_SATISFACTION,
+  MOCK_STAFF_PER_DEPARTMENT,
+  MOCK_ADMITTED_OVER_TIME,
+} from '@/mock/hospital/reports';
+
+// Bar colors are presentation-only; data comes from the mock layer.
+const WAIT_TIME_COLORS = ['#60A5FA', '#3B82F6', '#60A5FA', '#2563EB', '#93C5FD', '#6B84A8', '#BFDBFE'];
+const SATISFACTION_COLORS: Record<string, string> = {
+  Excellent: '#1E4D8C',
+  Good:      '#3B82F6',
+  Poor:      '#7DD3FC',
+};
+
+// Radar background bands — concentric hexagon rings alternating light-blue / white.
+const RADAR_MAX = 100;
+const RADAR_BANDS = [
+  { key: 'ring4', level: 100, fill: '#EDF2FB' },
+  { key: 'ring3', level: 75,  fill: '#FFFFFF' },
+  { key: 'ring2', level: 50,  fill: '#EDF2FB' },
+  { key: 'ring1', level: 25,  fill: '#FFFFFF' },
+];
+const STAFF_RADAR_DATA = MOCK_STAFF_PER_DEPARTMENT.map((d) => ({
+  ...d,
+  ring4: 100, ring3: 75, ring2: 50, ring1: 25,
+}));
+
+const tooltipStyle = {
+  borderRadius: 8,
+  border: 'none',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+  fontSize: 12,
+};
+
+// ── Chart card wrapper ─────────────────────────────────────────────────────────
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="space-y-6">
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Reports & Analysis</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
+    <div className="bg-white rounded-2xl p-5 shadow-sm border border-gray-100">
+      <h2 className="text-sm font-bold text-center mb-4" style={{ color: '#1E3A5F' }}>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+// ── Donut legend ───────────────────────────────────────────────────────────────
+function SatisfactionLegend() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 mt-2">
+      {MOCK_PATIENT_SATISFACTION.map((s) => (
+        <div key={s.name} className="flex items-center gap-2 text-xs text-gray-500">
+          <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: SATISFACTION_COLORS[s.name] }} />
+          {s.name} {s.value}%
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function HospitalAdminReportsPage() {
+  const [period] = useState('This Month');
+
+  return (
+    <div className="space-y-6 pb-8">
+
+      {/* Header */}
+      <div className="relative overflow-hidden rounded-2xl px-6 py-7 sm:px-8" style={{ background: '#EBF5FF' }}>
+        {/* Decorative trend illustration */}
+        <svg
+          className="hidden sm:block absolute right-6 top-1/2 -translate-y-1/2 opacity-50"
+          width="170" height="90" viewBox="0 0 170 90" fill="none" aria-hidden="true"
+        >
+          <path d="M5 78 L45 55 L80 60 L120 28 L160 10" stroke="#BFDBFE" strokeWidth="4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M150 10 L162 8 L160 22" stroke="#BFDBFE" strokeWidth="4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          <rect x="120" y="50" width="10" height="32" rx="2" fill="#DBEAFE" />
+          <rect x="136" y="38" width="10" height="44" rx="2" fill="#DBEAFE" />
+          <rect x="152" y="26" width="10" height="56" rx="2" fill="#DBEAFE" />
+        </svg>
+
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Reports &amp; Analysis</h1>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#38BDF8' }}>
+          Track the hospital reports and performance
+        </p>
+        <button
+          className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-[#1E4D8C] to-[#38BDF8] hover:opacity-90 transition shadow-sm"
+        >
+          <ClipboardDocumentListIcon className="w-4 h-4" />
+          {period}
+        </button>
+      </div>
+
+      {/* Charts grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+
+        {/* Average wait times by Department */}
+        <ChartCard title="Average wait times by Department">
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={MOCK_WAIT_TIMES} layout="vertical" margin={{ top: 0, right: 16, left: 8, bottom: 0 }} barCategoryGap={8}>
+              <XAxis type="number" domain={[0, 80]} ticks={[0, 20, 40, 60, 80]} tick={{ fontSize: 10, fill: '#9CA3AF' }} axisLine={false} tickLine={false} />
+              <YAxis type="category" dataKey="department" width={72} tick={{ fontSize: 9, fill: '#6B7280' }} axisLine={false} tickLine={false} />
+              <Tooltip formatter={(v: any) => [`${v} min`, 'Avg wait']} contentStyle={tooltipStyle} cursor={{ fill: 'rgba(219,234,254,0.4)' }} />
+              <Bar dataKey="minutes" radius={[0, 6, 6, 0]} barSize={14}>
+                {MOCK_WAIT_TIMES.map((d, i) => <Cell key={d.department} fill={WAIT_TIME_COLORS[i % WAIT_TIME_COLORS.length]} />)}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        {/* Patient Satisfaction */}
+        <ChartCard title="Patient Satisfaction">
+          <ResponsiveContainer width="100%" height={240}>
+            <PieChart>
+              <Pie data={MOCK_PATIENT_SATISFACTION} cx="50%" cy="50%" innerRadius={58} outerRadius={92} dataKey="value" paddingAngle={2} startAngle={90} endAngle={-270}>
+                {MOCK_PATIENT_SATISFACTION.map((s) => <Cell key={s.name} fill={SATISFACTION_COLORS[s.name]} />)}
+              </Pie>
+              <Tooltip formatter={(v: any, n: any) => [`${v}%`, n]} contentStyle={tooltipStyle} />
+            </PieChart>
+          </ResponsiveContainer>
+          <SatisfactionLegend />
+        </ChartCard>
+
+        {/* Staff Per Department*/}
+        <ChartCard title="Staff Per Department">
+          <ResponsiveContainer width="100%" height={260}>
+            <RadarChart data={STAFF_RADAR_DATA} outerRadius="72%">
+              <PolarRadiusAxis domain={[0, RADAR_MAX]} tickCount={5} tick={false} axisLine={false} />
+              {RADAR_BANDS.map((b) => (
+                <Radar
+                  key={b.key}
+                  dataKey={b.key}
+                  stroke="none"
+                  fill={b.fill}
+                  fillOpacity={1}
+                  isAnimationActive={false}
+                  legendType="none"
+                  tooltipType="none"
+                />
+              ))}
+              <PolarGrid stroke="#E5E7EB" />
+              <PolarAngleAxis dataKey="department" tick={{ fontSize: 10, fill: '#6B7280' }} />
+              <Radar dataKey="staff" stroke="#2563EB" strokeWidth={2} fill="#3B82F6" fillOpacity={0.25} />
+              <Tooltip formatter={(v: any) => [`${v} staff`, '']} contentStyle={tooltipStyle} />
+            </RadarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        {/*Admitted Patients over time*/}
+        <ChartCard title="Admitted Patients over time">
+          <ResponsiveContainer width="100%" height={260}>
+            <BarChart data={MOCK_ADMITTED_OVER_TIME} margin={{ top: 10, right: 8, left: -12, bottom: 0 }} barGap={4}>
+              <XAxis dataKey="period" tick={{ fontSize: 9, fill: '#9CA3AF' }} axisLine={false} tickLine={false} />
+              <YAxis domain={[0, 4000]} ticks={[0, 1000, 2000, 3000, 4000]} tick={{ fontSize: 10, fill: '#9CA3AF' }} axisLine={false} tickLine={false} />
+              <Tooltip contentStyle={tooltipStyle} cursor={{ fill: 'rgba(219,234,254,0.4)' }} />
+              <Legend iconType="rect" iconSize={10} wrapperStyle={{ fontSize: 11, color: '#6B7280' }} />
+              <Bar name="Admitted Patients" dataKey="admitted" fill="#1E4D8C" radius={[4, 4, 0, 0]} barSize={14} />
+              <Bar name="Outpatients" dataKey="outpatients" fill="#38BDF8" radius={[4, 4, 0, 0]} barSize={14} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
       </div>
     </div>
   );

--- a/src/mock/hospital/reports.ts
+++ b/src/mock/hospital/reports.ts
@@ -3,7 +3,15 @@
 // → frontend uses mock data until the aggregate reporting engine is deployed
 // CSV export endpoints are live: GET /api/reports/export/appointments|revenue|prescriptions
 // The mock data includes a summary of key metrics for the hospital, such as total patients, new admissions, discharges, and average stay duration. It also includes datasets for visualizations like line charts showing admissions over time and donut charts breaking down diagnoses by category. This allows the frontend to display a rich reporting dashboard with insights into hospital operations and patient trends without needing live backend data during development.
-import type { ReportSummary, AdmissionDataPoint, DiagnosisBreakdown } from '@/types/hospital';
+import type {
+  ReportSummary,
+  AdmissionDataPoint,
+  DiagnosisBreakdown,
+  DepartmentWaitTime,
+  SatisfactionSlice,
+  DepartmentStaffCount,
+  AdmissionsTrendPoint,
+} from '@/types/hospital';
 
 export const MOCK_REPORT_SUMMARY: ReportSummary = {
   totalPatients: 412,
@@ -51,4 +59,43 @@ export const MOCK_DIAGNOSIS_BREAKDOWN: DiagnosisBreakdown[] = [
   { name: 'Diabetes',       value: 15 },
   { name: 'Respiratory',    value: 18 },
   { name: 'Other',          value: 17 },
+];
+
+// Analytics charts (per Figma) 
+
+// Average wait time (minutes) per department — horizontal bar chart
+export const MOCK_WAIT_TIMES: DepartmentWaitTime[] = [
+  { department: 'Cardiology',  minutes: 45 },
+  { department: 'Dermatology', minutes: 55 },
+  { department: 'Neurology',   minutes: 50 },
+  { department: 'Orthopedics', minutes: 62 },
+  { department: 'Oncology',    minutes: 34 },
+  { department: 'Gynecology',  minutes: 78 },
+  { department: 'Surgery',     minutes: 22 },
+];
+
+// Patient satisfaction split — donut chart
+export const MOCK_PATIENT_SATISFACTION: SatisfactionSlice[] = [
+  { name: 'Excellent', value: 60 },
+  { name: 'Good',      value: 25 },
+  { name: 'Poor',      value: 15 },
+];
+
+// Staff headcount per department — radar chart
+export const MOCK_STAFF_PER_DEPARTMENT: DepartmentStaffCount[] = [
+  { department: 'Cardiology',  staff: 80 },
+  { department: 'Surgery',     staff: 95 },
+  { department: 'Dermatology', staff: 55 },
+  { department: 'Gynecology',  staff: 70 },
+  { department: 'Orthopedics', staff: 60 },
+  { department: 'Neurology',   staff: 48 },
+];
+
+// Admitted vs outpatient volume over time — grouped bar chart
+export const MOCK_ADMITTED_OVER_TIME: AdmissionsTrendPoint[] = [
+  { period: 'Jan - Feb', admitted: 3900, outpatients: 1500 },
+  { period: 'Mar - Apr', admitted: 2200, outpatients: 3200 },
+  { period: 'May - Jun', admitted: 3300, outpatients: 2500 },
+  { period: 'Jul - Aug', admitted: 3400, outpatients: 950  },
+  { period: 'Sep - Oct', admitted: 1300, outpatients: 3600 },
 ];

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -236,6 +236,28 @@ export interface DiagnosisBreakdown {
   value: number;
 }
 
+// Analytics charts shown on the Reports & Analysis page (Figma)
+export interface DepartmentWaitTime {
+  department: string;
+  minutes: number;
+}
+
+export interface SatisfactionSlice {
+  name: 'Excellent' | 'Good' | 'Poor';
+  value: number;
+}
+
+export interface DepartmentStaffCount {
+  department: string;
+  staff: number;
+}
+
+export interface AdmissionsTrendPoint {
+  period: string;
+  admitted: number;
+  outpatients: number;
+}
+
 // ── Settings ──────────────────────────────────────────────────────────────────
 
 export interface HospitalSettings {


### PR DESCRIPTION
## Summary

This PR implements the Reports & Analytics page for Hospital Superadmin per the Figma design, replacing the previous stub with wait-time, satisfaction, staff distribution, and admissions trend visualizations.

## Changes
- Added header card with title, subtitle, "This Month" filter control, and trend illustration
- Added Average Wait Times by Department horizontal bar chart
- Added Patient Satisfaction donut chart (Excellent/Good/Poor)
- Added Staff Per Department radar chart with banded background matching Figma
- Added Admitted Patients vs Outpatients grouped bar chart over time
- Extended `src/mock/hospital/reports.ts` with new datasets (`MOCK_WAIT_TIMES`, `MOCK_PATIENT_SATISFACTION`, `MOCK_STAFF_PER_DEPARTMENT`, `MOCK_ADMITTED_OVER_TIME`) and corresponding types in `src/types/hospital.ts`
- 2x2 responsive grid on desktop, single column on mobile, using `recharts`

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [x] Super-admin
- [ ] Shared / cross-cutting

## How to test
1. Log in as **Hospital Superadmin**, then Reports & Analytics
2. Verify the page matches the Figma design (header card, four charts in a 2x2 grid)
3. Resize to mobile width; charts should stack into a single column
4. Hover over chart elements to confirm tooltips render correctly
5. Confirm "This Month" filter button is visually present (no functionality required per scope)

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->