### PR TITLE
feat: hospital admin Schedule & Appointments pages

### DIFF
--- a/src/app/hospital/admin/appointments/page.tsx
+++ b/src/app/hospital/admin/appointments/page.tsx
@@ -79,8 +79,8 @@ export default function HospitalAdminAppointmentsPage() {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: NAVY }}>
+      <div className="rounded-2xl px-4 py-5 sm:p-8" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-2xl sm:text-3xl font-bold" style={{ color: NAVY }}>
           Appointment Scheduling &amp; Tracking
         </h1>
         <p className="mt-1 text-sm text-gray-500">
@@ -91,8 +91,8 @@ export default function HospitalAdminAppointmentsPage() {
       {/* Table card */}
       <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
         {/* Filter bar */}
-        <div className="p-4 border-b border-gray-100 flex flex-wrap gap-3 items-center">
-          <div className="relative flex-1 min-w-[160px]">
+        <div className="p-3 sm:p-4 border-b border-gray-100 flex flex-wrap gap-2 sm:gap-3 items-center">
+          <div className="relative flex-1 min-w-[140px]">
             <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
             <input
               type="text"
@@ -148,12 +148,12 @@ export default function HospitalAdminAppointmentsPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
-                <th className="px-6 py-3">Patient Name</th>
-                <th className="px-6 py-3">Assigned Doctor</th>
-                <th className="px-6 py-3">Department</th>
-                <th className="px-6 py-3">Scheduled Date &amp; Time</th>
-                <th className="px-6 py-3">Status</th>
-                <th className="px-6 py-3">Options</th>
+                <th className="px-4 sm:px-6 py-3">Patient Name</th>
+                <th className="px-4 sm:px-6 py-3">Assigned Doctor</th>
+                <th className="hidden md:table-cell px-6 py-3">Department</th>
+                <th className="hidden sm:table-cell px-6 py-3">Scheduled Date &amp; Time</th>
+                <th className="px-4 sm:px-6 py-3">Status</th>
+                <th className="px-4 sm:px-6 py-3">Options</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
@@ -162,11 +162,11 @@ export default function HospitalAdminAppointmentsPage() {
                 const dm = DEPT_META[a.specialization] ?? { bg: '#F3F4F6', color: '#374151' };
                 return (
                   <tr key={a.id} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-6 py-4 font-semibold" style={{ color: NAVY }}>
+                    <td className="px-4 sm:px-6 py-4 font-semibold" style={{ color: NAVY }}>
                       {a.patientName}
                     </td>
-                    <td className="px-6 py-4 text-gray-600">{a.doctorName}</td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 sm:px-6 py-4 text-gray-600">{a.doctorName}</td>
+                    <td className="hidden md:table-cell px-6 py-4">
                       <span
                         className="inline-block px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide whitespace-nowrap"
                         style={{ background: dm.bg, color: dm.color }}
@@ -174,10 +174,10 @@ export default function HospitalAdminAppointmentsPage() {
                         {a.specialization}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-gray-600 whitespace-nowrap">
+                    <td className="hidden sm:table-cell px-6 py-4 text-gray-600 whitespace-nowrap">
                       {formatDateTime(a.date)}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 sm:px-6 py-4">
                       <span
                         className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold whitespace-nowrap"
                         style={{ background: sm.bg, color: sm.color }}
@@ -186,7 +186,7 @@ export default function HospitalAdminAppointmentsPage() {
                         {sm.label}
                       </span>
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 sm:px-6 py-4">
                       <div className="flex items-center gap-1">
                         <button
                           className="p-1.5 rounded-lg hover:bg-blue-50 text-blue-400 transition-colors"

--- a/src/app/hospital/admin/appointments/page.tsx
+++ b/src/app/hospital/admin/appointments/page.tsx
@@ -13,12 +13,12 @@ import type { AppointmentStatus } from '@/types/hospital';
 const NAVY = '#1E3A5F';
 const TEAL = '#38BDF8';
 
-const STATUS_META: Record<AppointmentStatus, { label: string; bg: string; color: string }> = {
-  CONFIRMED:        { label: 'Confirmed',     bg: '#DCFCE7', color: '#166534' },
-  PENDING:          { label: 'Pending',        bg: '#FEF9C3', color: '#854D0E' },
-  CANCELLED:        { label: 'Cancelled',      bg: '#FEE2E2', color: '#991B1B' },
-  READY_FOR_DOCTOR: { label: 'Ready',          bg: '#DBEAFE', color: '#1E40AF' },
-  COMPLETED:        { label: 'Completed',      bg: '#F3F4F6', color: '#4B5563' },
+const STATUS_META: Record<AppointmentStatus, { label: string; dot: string; bg: string; color: string }> = {
+  CONFIRMED:        { label: 'CONFIRMED',  dot: '#16A34A', bg: '#DCFCE7', color: '#166534' },
+  PENDING:          { label: 'PENDING',    dot: '#D97706', bg: '#FEF9C3', color: '#854D0E' },
+  CANCELLED:        { label: 'CANCELLED',  dot: '#DC2626', bg: '#FEE2E2', color: '#991B1B' },
+  READY_FOR_DOCTOR: { label: 'READY',      dot: '#2563EB', bg: '#DBEAFE', color: '#1E40AF' },
+  COMPLETED:        { label: 'COMPLETED',  dot: '#6B7280', bg: '#F3F4F6', color: '#4B5563' },
 };
 
 const DEPT_META: Record<string, { bg: string; color: string }> = {
@@ -179,9 +179,10 @@ export default function HospitalAdminAppointmentsPage() {
                     </td>
                     <td className="px-6 py-4">
                       <span
-                        className="inline-block px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap"
+                        className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold whitespace-nowrap"
                         style={{ background: sm.bg, color: sm.color }}
                       >
+                        <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: sm.dot }} />
                         {sm.label}
                       </span>
                     </td>

--- a/src/app/hospital/admin/appointments/page.tsx
+++ b/src/app/hospital/admin/appointments/page.tsx
@@ -1,9 +1,220 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import {
+  MagnifyingGlassIcon,
+  ChevronDownIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import { MOCK_APPOINTMENTS } from '@/mock/hospital/appointments';
+import type { AppointmentStatus } from '@/types/hospital';
+
+const NAVY = '#1E3A5F';
+const TEAL = '#38BDF8';
+
+const STATUS_META: Record<AppointmentStatus, { label: string; bg: string; color: string }> = {
+  CONFIRMED:        { label: 'Confirmed',     bg: '#DCFCE7', color: '#166534' },
+  PENDING:          { label: 'Pending',        bg: '#FEF9C3', color: '#854D0E' },
+  CANCELLED:        { label: 'Cancelled',      bg: '#FEE2E2', color: '#991B1B' },
+  READY_FOR_DOCTOR: { label: 'Ready',          bg: '#DBEAFE', color: '#1E40AF' },
+  COMPLETED:        { label: 'Completed',      bg: '#F3F4F6', color: '#4B5563' },
+};
+
+const DEPT_META: Record<string, { bg: string; color: string }> = {
+  'Cardiology':       { bg: '#FFE4E6', color: '#9F1239' },
+  'General Medicine': { bg: '#DBEAFE', color: '#1D4ED8' },
+  'Paediatrics':      { bg: '#DCFCE7', color: '#166534' },
+  'Surgery':          { bg: '#FED7AA', color: '#C2410C' },
+  'Neurology':        { bg: '#EDE9FE', color: '#5B21B6' },
+  'Orthopaedics':     { bg: '#FEF3C7', color: '#92400E' },
+  'Dermatology':      { bg: '#FCE7F3', color: '#9D174D' },
+};
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso);
+  const date = d.toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+  });
+  const time = d.toLocaleTimeString('en-US', {
+    hour: '2-digit', minute: '2-digit', timeZone: 'UTC',
+  });
+  return `${date}, ${time}`;
+}
+
 export default function HospitalAdminAppointmentsPage() {
+  const [search, setSearch] = useState('');
+  const [doctorFilter, setDoctorFilter] = useState('');
+  const [deptFilter, setDeptFilter] = useState('');
+  const [dateFilter, setDateFilter] = useState('');
+
+  const doctors = useMemo(
+    () => [...new Set(MOCK_APPOINTMENTS.map(a => a.doctorName))].sort(),
+    [],
+  );
+  const departments = useMemo(
+    () => [...new Set(MOCK_APPOINTMENTS.map(a => a.specialization))].sort(),
+    [],
+  );
+
+  const filtered = useMemo(() =>
+    MOCK_APPOINTMENTS.filter(a => {
+      const q = search.toLowerCase();
+      if (q && !a.patientName.toLowerCase().includes(q) && !a.doctorName.toLowerCase().includes(q)) return false;
+      if (doctorFilter && a.doctorName !== doctorFilter) return false;
+      if (deptFilter && a.specialization !== deptFilter) return false;
+      if (dateFilter && !a.date.startsWith(dateFilter)) return false;
+      return true;
+    }),
+    [search, doctorFilter, deptFilter, dateFilter],
+  );
+
+  const resetFilters = () => {
+    setSearch('');
+    setDoctorFilter('');
+    setDeptFilter('');
+    setDateFilter('');
+  };
+
   return (
     <div className="space-y-6">
+      {/* Page header */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Appointments</h1>
-        <p className="mt-1 text-sm font-medium" style={{ color: '#2D9B8A' }}>Manage hospital appointments</p>
+        <h1 className="text-3xl font-bold" style={{ color: NAVY }}>
+          Appointment Scheduling &amp; Tracking
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Manage and track scheduled patient appointments
+        </p>
+      </div>
+
+      {/* Table card */}
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        {/* Filter bar */}
+        <div className="p-4 border-b border-gray-100 flex flex-wrap gap-3 items-center">
+          <div className="relative flex-1 min-w-[160px]">
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search patient or doctor..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-200"
+            />
+          </div>
+
+          <div className="relative">
+            <select
+              value={doctorFilter}
+              onChange={e => setDoctorFilter(e.target.value)}
+              className="appearance-none pl-3 pr-8 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 min-w-[130px]"
+            >
+              <option value="">All Doctors</option>
+              {doctors.map(d => <option key={d} value={d}>{d}</option>)}
+            </select>
+            <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          </div>
+
+          <div className="relative">
+            <select
+              value={deptFilter}
+              onChange={e => setDeptFilter(e.target.value)}
+              className="appearance-none pl-3 pr-8 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 min-w-[150px]"
+            >
+              <option value="">All Departments</option>
+              {departments.map(d => <option key={d} value={d}>{d}</option>)}
+            </select>
+            <ChevronDownIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          </div>
+
+          <input
+            type="date"
+            value={dateFilter}
+            onChange={e => setDateFilter(e.target.value)}
+            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-200"
+          />
+
+          <button
+            onClick={resetFilters}
+            className="px-4 py-2 text-sm font-semibold text-white rounded-lg transition-opacity hover:opacity-90"
+            style={{ backgroundColor: TEAL }}
+          >
+            Reset
+          </button>
+        </div>
+
+        {/* Table */}
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-xs font-semibold uppercase tracking-wide text-gray-400">
+                <th className="px-6 py-3">Patient Name</th>
+                <th className="px-6 py-3">Assigned Doctor</th>
+                <th className="px-6 py-3">Department</th>
+                <th className="px-6 py-3">Scheduled Date &amp; Time</th>
+                <th className="px-6 py-3">Status</th>
+                <th className="px-6 py-3">Options</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {filtered.map(a => {
+                const sm = STATUS_META[a.status];
+                const dm = DEPT_META[a.specialization] ?? { bg: '#F3F4F6', color: '#374151' };
+                return (
+                  <tr key={a.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-6 py-4 font-semibold" style={{ color: NAVY }}>
+                      {a.patientName}
+                    </td>
+                    <td className="px-6 py-4 text-gray-600">{a.doctorName}</td>
+                    <td className="px-6 py-4">
+                      <span
+                        className="inline-block px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide whitespace-nowrap"
+                        style={{ background: dm.bg, color: dm.color }}
+                      >
+                        {a.specialization}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-gray-600 whitespace-nowrap">
+                      {formatDateTime(a.date)}
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className="inline-block px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap"
+                        style={{ background: sm.bg, color: sm.color }}
+                      >
+                        {sm.label}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-1">
+                        <button
+                          className="p-1.5 rounded-lg hover:bg-blue-50 text-blue-400 transition-colors"
+                          title="Edit appointment"
+                        >
+                          <PencilSquareIcon className="w-4 h-4" />
+                        </button>
+                        <button
+                          className="p-1.5 rounded-lg hover:bg-red-50 text-red-400 transition-colors"
+                          title="Delete appointment"
+                        >
+                          <TrashIcon className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-6 py-12 text-center text-gray-400">
+                    No appointments match your filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/app/hospital/admin/schedule/page.tsx
+++ b/src/app/hospital/admin/schedule/page.tsx
@@ -1,9 +1,214 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon, VideoCameraIcon, UserIcon } from '@heroicons/react/24/outline';
+import { MOCK_SCHEDULE, DOCTOR_COLORS } from '@/mock/hospital/schedule';
+import type { ScheduleEntry } from '@/types/hospital';
+
+const NAVY = '#1E3A5F';
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+const HOUR_SLOTS = ['08:00', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00'];
+
+function getWeekDates(monday: Date): Date[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(monday);
+    d.setUTCDate(d.getUTCDate() + i);
+    return d;
+  });
+}
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function parseMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
 export default function HospitalAdminSchedulePage() {
+  // Default to the mock data week (June 2, 2026 — a Monday)
+  const [weekStart, setWeekStart] = useState(() => new Date('2026-06-02'));
+
+  const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart]);
+
+  const prevWeek = () => {
+    const d = new Date(weekStart);
+    d.setUTCDate(d.getUTCDate() - 7);
+    setWeekStart(d);
+  };
+
+  const nextWeek = () => {
+    const d = new Date(weekStart);
+    d.setUTCDate(d.getUTCDate() + 7);
+    setWeekStart(d);
+  };
+
+  const entriesByDay = useMemo(() => {
+    const map = new Map<string, ScheduleEntry[]>();
+    for (const date of weekDates) {
+      map.set(toISODate(date), []);
+    }
+    for (const entry of MOCK_SCHEDULE) {
+      if (map.has(entry.date)) {
+        map.get(entry.date)!.push(entry);
+      }
+    }
+    return map;
+  }, [weekDates]);
+
+  const weekLabel = `${weekDates[0].toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', timeZone: 'UTC',
+  })} – ${weekDates[6].toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC',
+  })}`;
+
+  const doctorLegend = useMemo(() => {
+    const seen = new Set<string>();
+    const result: { id: string; name: string; color: string }[] = [];
+    for (const e of MOCK_SCHEDULE) {
+      const did = e.doctorId ?? '';
+      if (did && !seen.has(did)) {
+        seen.add(did);
+        result.push({ id: did, name: e.doctorName ?? '', color: DOCTOR_COLORS[did] ?? '#999' });
+      }
+    }
+    return result;
+  }, []);
+
   return (
     <div className="space-y-6">
+      {/* Page header */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Schedule</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
+        <h1 className="text-3xl font-bold" style={{ color: NAVY }}>Schedule</h1>
+        <p className="mt-1 text-sm text-gray-500">Weekly appointment calendar</p>
+      </div>
+
+      {/* Calendar card */}
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        {/* Week navigation */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <div>
+            <h2 className="text-base font-bold" style={{ color: NAVY }}>Weekly Health Plan</h2>
+            <p className="text-xs text-gray-400 mt-0.5">{weekLabel}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={prevWeek}
+              className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+              aria-label="Previous week"
+            >
+              <ChevronLeftIcon className="w-5 h-5 text-gray-500" />
+            </button>
+            <button
+              onClick={nextWeek}
+              className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+              aria-label="Next week"
+            >
+              <ChevronRightIcon className="w-5 h-5 text-gray-500" />
+            </button>
+          </div>
+        </div>
+
+        {/* Calendar grid — scrollable horizontally on small screens */}
+        <div className="overflow-x-auto">
+          <div className="min-w-[640px]">
+            {/* Day header row */}
+            <div
+              className="grid border-b border-gray-100"
+              style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}
+            >
+              <div />
+              {weekDates.map((d, i) => (
+                <div key={i} className="py-3 text-center border-l border-gray-100">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+                    {DAY_LABELS[i]}
+                  </p>
+                  <p className="text-sm font-bold mt-0.5" style={{ color: NAVY }}>
+                    {d.getUTCDate()}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            {/* Hour rows */}
+            {HOUR_SLOTS.map(hour => {
+              const slotStart = parseMinutes(hour);
+              const slotEnd = slotStart + 60;
+              return (
+                <div
+                  key={hour}
+                  className="grid border-t border-gray-50"
+                  style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}
+                >
+                  {/* Hour label */}
+                  <div className="px-2 py-2 text-xs text-gray-400 font-medium text-right leading-none pt-2.5">
+                    {hour}
+                  </div>
+
+                  {/* Day cells */}
+                  {weekDates.map((d, dayIdx) => {
+                    const dayEntries = (entriesByDay.get(toISODate(d)) ?? []).filter(e => {
+                      const start = parseMinutes(e.startTime ?? '00:00');
+                      return start >= slotStart && start < slotEnd;
+                    });
+
+                    return (
+                      <div
+                        key={dayIdx}
+                        className="border-l border-gray-100 min-h-[72px] p-1 space-y-1"
+                      >
+                        {dayEntries.map(entry => {
+                          const hexColor = DOCTOR_COLORS[entry.doctorId ?? ''] ?? '#2D9B8A';
+                          return (
+                            <div
+                              key={entry.id}
+                              className="rounded-lg px-2 py-1.5 text-white text-xs"
+                              style={{ backgroundColor: hexColor }}
+                            >
+                              <p className="font-semibold truncate leading-tight">
+                                {entry.patientName}
+                              </p>
+                              <p className="opacity-90 truncate leading-tight">
+                                {(entry.doctorName ?? '').replace('Dr. ', '')}
+                              </p>
+                              <p className="opacity-75 leading-tight">
+                                {entry.startTime}–{entry.endTime}
+                              </p>
+                              <div className="flex items-center gap-1 opacity-80 mt-0.5">
+                                {entry.type === 'ONLINE'
+                                  ? <VideoCameraIcon className="w-3 h-3 shrink-0" />
+                                  : <UserIcon className="w-3 h-3 shrink-0" />}
+                                <span>{entry.type === 'ONLINE' ? 'Online' : 'In-person'}</span>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Doctor colour legend */}
+        <div className="px-6 py-4 border-t border-gray-100">
+          <div className="flex flex-wrap gap-x-5 gap-y-2">
+            {doctorLegend.map(doc => (
+              <div key={doc.id} className="flex items-center gap-2">
+                <div
+                  className="w-3 h-3 rounded-full shrink-0"
+                  style={{ backgroundColor: doc.color }}
+                />
+                <span className="text-xs text-gray-600">{doc.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/hospital/admin/schedule/page.tsx
+++ b/src/app/hospital/admin/schedule/page.tsx
@@ -1,36 +1,100 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { ChevronLeftIcon, ChevronRightIcon, VideoCameraIcon, UserIcon } from '@heroicons/react/24/outline';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  VideoCameraIcon,
+  UserIcon,
+  PhoneIcon,
+  MagnifyingGlassIcon,
+  Cog6ToothIcon,
+  PlusIcon,
+  ChevronDownIcon,
+  CalendarDaysIcon,
+} from '@heroicons/react/24/outline';
 import { MOCK_SCHEDULE, DOCTOR_COLORS } from '@/mock/hospital/schedule';
 import type { ScheduleEntry } from '@/types/hospital';
 
 const NAVY = '#1E3A5F';
+const TEAL = '#38BDF8';
 
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+// Pastel card palette keyed to the color field on ScheduleEntry
+const CARD_PALETTE: Record<string, { bg: string; fg: string }> = {
+  blue:   { bg: '#EFF6FF', fg: '#1E40AF' },
+  green:  { bg: '#F0FDF4', fg: '#166534' },
+  purple: { bg: '#F5F3FF', fg: '#5B21B6' },
+  orange: { bg: '#FFF7ED', fg: '#9A3412' },
+  red:    { bg: '#FFF1F2', fg: '#9F1239' },
+};
 
-const HOUR_SLOTS = ['08:00', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00'];
+function cardColors(color: string) {
+  return CARD_PALETTE[color] ?? CARD_PALETTE.blue;
+}
+
+function typeDisplay(type?: string): { label: string; Icon: React.ElementType } {
+  if (type === 'VIDEO_CALL' || type === 'ONLINE') return { label: 'Video Call', Icon: VideoCameraIcon };
+  if (type === 'AUDIO_CALL') return { label: 'Audio Call', Icon: PhoneIcon };
+  return { label: 'In Person', Icon: UserIcon };
+}
+
+// ── Date helpers ────────────────────────────────────────────────────────────
+
+function getMondayOfWeek(d: Date): Date {
+  const dow = d.getUTCDay(); // 0=Sun
+  const diff = dow === 0 ? -6 : 1 - dow;
+  const m = new Date(d);
+  m.setUTCDate(d.getUTCDate() + diff);
+  return m;
+}
 
 function getWeekDates(monday: Date): Date[] {
   return Array.from({ length: 7 }, (_, i) => {
     const d = new Date(monday);
-    d.setUTCDate(d.getUTCDate() + i);
+    d.setUTCDate(monday.getUTCDate() + i);
     return d;
   });
 }
 
-function toISODate(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
+function toISO(d: Date) { return d.toISOString().slice(0, 10); }
 
-function parseMinutes(t: string): number {
-  const [h, m] = t.split(':').map(Number);
+function parseMin(t: string) {
+  const [h, m] = (t ?? '00:00').split(':').map(Number);
   return h * 60 + m;
 }
 
+function fmt12(h: number) {
+  return h === 12 ? '12 PM' : h > 12 ? `${h - 12} PM` : `${h} AM`;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const HOUR_SLOTS = [8, 9, 10, 11, 12, 13, 14, 15];
+const DAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'];
+const DOW_ABBR = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+// Mock "today" anchored to the demo data week so the calendar pre-loads with data
+const MOCK_TODAY = new Date('2026-06-02T00:00:00Z');
+
+// ── Component ────────────────────────────────────────────────────────────────
+
 export default function HospitalAdminSchedulePage() {
-  // Default to the mock data week (June 2, 2026 — a Monday)
-  const [weekStart, setWeekStart] = useState(() => new Date('2026-06-02'));
+  const todayStr = toISO(MOCK_TODAY);
+
+  // Week being viewed
+  const [weekStart, setWeekStart] = useState(() => getMondayOfWeek(MOCK_TODAY));
+
+  // Mini-calendar month being shown
+  const [calYear, setCalYear] = useState(MOCK_TODAY.getUTCFullYear());
+  const [calMonth, setCalMonth] = useState(MOCK_TODAY.getUTCMonth());
+
+  // Mobile left-panel visibility
+  const [leftOpen, setLeftOpen] = useState(false);
+
+  // Week / Month tab (Month is visual only — no grid change)
+  const [viewMode, setViewMode] = useState<'week' | 'month'>('week');
 
   const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart]);
 
@@ -48,165 +112,314 @@ export default function HospitalAdminSchedulePage() {
 
   const entriesByDay = useMemo(() => {
     const map = new Map<string, ScheduleEntry[]>();
-    for (const date of weekDates) {
-      map.set(toISODate(date), []);
-    }
-    for (const entry of MOCK_SCHEDULE) {
-      if (map.has(entry.date)) {
-        map.get(entry.date)!.push(entry);
-      }
+    for (const wd of weekDates) map.set(toISO(wd), []);
+    for (const e of MOCK_SCHEDULE) {
+      if (map.has(e.date)) map.get(e.date)!.push(e);
     }
     return map;
   }, [weekDates]);
 
-  const weekLabel = `${weekDates[0].toLocaleDateString('en-US', {
-    month: 'short', day: 'numeric', timeZone: 'UTC',
-  })} – ${weekDates[6].toLocaleDateString('en-US', {
-    month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC',
-  })}`;
+  const weekLabel = `${weekDates[0].toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })} – ${weekDates[6].toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}`;
 
+  // Mini-calendar helpers
+  const daysInMonth = new Date(Date.UTC(calYear, calMonth + 1, 0)).getUTCDate();
+  const firstDow    = new Date(Date.UTC(calYear, calMonth, 1)).getUTCDay(); // 0=Sun
+
+  const handleCalDay = (day: number) => {
+    const clicked = new Date(Date.UTC(calYear, calMonth, day));
+    setWeekStart(getMondayOfWeek(clicked));
+  };
+
+  const prevCalMonth = () => calMonth === 0 ? (setCalYear(y => y - 1), setCalMonth(11)) : setCalMonth(m => m - 1);
+  const nextCalMonth = () => calMonth === 11 ? (setCalYear(y => y + 1), setCalMonth(0)) : setCalMonth(m => m + 1);
+
+  // Doctor legend
   const doctorLegend = useMemo(() => {
     const seen = new Set<string>();
-    const result: { id: string; name: string; color: string }[] = [];
-    for (const e of MOCK_SCHEDULE) {
-      const did = e.doctorId ?? '';
-      if (did && !seen.has(did)) {
-        seen.add(did);
-        result.push({ id: did, name: e.doctorName ?? '', color: DOCTOR_COLORS[did] ?? '#999' });
+    return MOCK_SCHEDULE.reduce<{ id: string; name: string; color: string }[]>((acc, e) => {
+      const id = e.doctorId ?? '';
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        acc.push({ id, name: e.doctorName ?? '', color: DOCTOR_COLORS[id] ?? '#999' });
       }
-    }
-    return result;
+      return acc;
+    }, []);
   }, []);
 
-  return (
-    <div className="space-y-6">
-      {/* Page header */}
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: NAVY }}>Schedule</h1>
-        <p className="mt-1 text-sm text-gray-500">Weekly appointment calendar</p>
+  // ── Left panel ─────────────────────────────────────────────────────────────
+
+  const leftPanel = (
+    <div className="space-y-3">
+      {/* Mini calendar */}
+      <div className="bg-white rounded-2xl p-4 shadow-sm">
+        <div className="flex items-center justify-between mb-2">
+          <button onClick={prevCalMonth} className="p-1 rounded-lg hover:bg-gray-100">
+            <ChevronLeftIcon className="w-3.5 h-3.5 text-gray-500" />
+          </button>
+          <span className="text-[11px] font-bold" style={{ color: NAVY }}>
+            {MONTH_NAMES[calMonth]} {calYear}
+          </span>
+          <button onClick={nextCalMonth} className="p-1 rounded-lg hover:bg-gray-100">
+            <ChevronRightIcon className="w-3.5 h-3.5 text-gray-500" />
+          </button>
+        </div>
+
+        {/* Day-of-week header */}
+        <div className="grid grid-cols-7 mb-1">
+          {DOW_ABBR.map((d, i) => (
+            <div key={i} className="text-center text-[9px] font-semibold text-gray-400">{d}</div>
+          ))}
+        </div>
+
+        {/* Day grid */}
+        <div className="grid grid-cols-7 gap-y-0.5">
+          {Array.from({ length: firstDow }, (_, i) => <div key={`e${i}`} />)}
+          {Array.from({ length: daysInMonth }, (_, i) => {
+            const day = i + 1;
+            const dateStr = `${calYear}-${String(calMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+            const isToday  = dateStr === todayStr;
+            const isInWeek = weekDates.some(d => toISO(d) === dateStr);
+            return (
+              <button
+                key={day}
+                onClick={() => handleCalDay(day)}
+                className="w-6 h-6 mx-auto flex items-center justify-center text-[11px] rounded-full transition-colors hover:opacity-90"
+                style={
+                  isToday  ? { backgroundColor: TEAL,  color: '#fff', fontWeight: 700 } :
+                  isInWeek ? { backgroundColor: NAVY,  color: '#fff', opacity: 0.55 }  :
+                             { color: '#374151' }
+                }
+              >
+                {day}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {/* Calendar card */}
-      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-        {/* Week navigation */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-          <div>
-            <h2 className="text-base font-bold" style={{ color: NAVY }}>Weekly Health Plan</h2>
-            <p className="text-xs text-gray-400 mt-0.5">{weekLabel}</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={prevWeek}
-              className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-              aria-label="Previous week"
-            >
-              <ChevronLeftIcon className="w-5 h-5 text-gray-500" />
-            </button>
-            <button
-              onClick={nextWeek}
-              className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-              aria-label="Next week"
-            >
-              <ChevronRightIcon className="w-5 h-5 text-gray-500" />
-            </button>
+      {/* Search for people */}
+      <div className="bg-white rounded-2xl px-3 py-2.5 shadow-sm">
+        <div className="relative">
+          <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search for people"
+            className="w-full pl-8 pr-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-200"
+          />
+        </div>
+      </div>
+
+      {/* Booking pages + My/Other calendars */}
+      <div className="bg-white rounded-2xl p-4 shadow-sm space-y-4">
+        <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">Booking Pages</p>
+
+        {/* My calendars */}
+        <div>
+          <button className="flex items-center gap-1.5 text-[11px] font-semibold text-gray-700 w-full">
+            <ChevronDownIcon className="w-3 h-3 shrink-0" />
+            My calendars
+          </button>
+          <div className="mt-2 pl-4">
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: TEAL }} />
+              <span className="text-[11px] text-gray-600">Hospital Admin</span>
+            </div>
           </div>
         </div>
 
-        {/* Calendar grid — scrollable horizontally on small screens */}
-        <div className="overflow-x-auto">
-          <div className="min-w-[640px]">
-            {/* Day header row */}
-            <div
-              className="grid border-b border-gray-100"
-              style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}
-            >
-              <div />
-              {weekDates.map((d, i) => (
-                <div key={i} className="py-3 text-center border-l border-gray-100">
-                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
-                    {DAY_LABELS[i]}
-                  </p>
-                  <p className="text-sm font-bold mt-0.5" style={{ color: NAVY }}>
-                    {d.getUTCDate()}
-                  </p>
-                </div>
-              ))}
+        {/* Other calendars */}
+        <div>
+          <button className="flex items-center gap-1.5 text-[11px] font-semibold text-gray-700 w-full group">
+            <PlusIcon className="w-3 h-3 shrink-0 group-hover:text-sky-500 transition-colors" />
+            Other calendars
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div>
+      {/* Mobile panel toggle */}
+      <button
+        className="lg:hidden mb-4 inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold text-white"
+        style={{ backgroundColor: NAVY }}
+        onClick={() => setLeftOpen(o => !o)}
+      >
+        <CalendarDaysIcon className="w-4 h-4" />
+        {leftOpen ? 'Hide panel' : 'Calendar panel'}
+      </button>
+
+      <div className="flex gap-5 items-start">
+        {/* Left panel */}
+        <aside className={`w-52 shrink-0 ${leftOpen ? 'block' : 'hidden'} lg:block`}>
+          {leftPanel}
+        </aside>
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0 space-y-4">
+          {/* Page header */}
+          <div className="rounded-2xl px-8 py-6" style={{ background: '#EBF5FF' }}>
+            <div className="flex items-start justify-between flex-wrap gap-3">
+              <div>
+                <h1 className="text-3xl font-extrabold tracking-tight" style={{ color: NAVY }}>
+                  SCHEDULE
+                </h1>
+                <p className="mt-0.5 text-sm text-gray-500">Appointment list &middot; Today</p>
+              </div>
+              <button
+                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                style={{ backgroundColor: TEAL }}
+              >
+                Try now
+                <ChevronRightIcon className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Calendar card */}
+          <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+            {/* Navigation bar */}
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100 flex-wrap">
+              {/* Week / Month toggle */}
+              <div className="flex rounded-lg border border-gray-200 overflow-hidden text-xs font-semibold">
+                <button
+                  onClick={() => setViewMode('week')}
+                  className="px-4 py-1.5 transition-colors"
+                  style={viewMode === 'week' ? { backgroundColor: NAVY, color: '#fff' } : { color: '#6B7280' }}
+                >
+                  Week
+                </button>
+                <button
+                  onClick={() => setViewMode('month')}
+                  className="px-4 py-1.5 transition-colors"
+                  style={viewMode === 'month' ? { backgroundColor: NAVY, color: '#fff' } : { color: '#6B7280' }}
+                >
+                  Month
+                </button>
+              </div>
+
+              {/* Arrows + date range */}
+              <div className="flex items-center gap-1 flex-1 justify-center min-w-0">
+                <button onClick={prevWeek} className="p-1.5 rounded-lg hover:bg-gray-100 shrink-0">
+                  <ChevronLeftIcon className="w-4 h-4 text-gray-500" />
+                </button>
+                <span className="text-xs font-semibold px-1 truncate" style={{ color: NAVY }}>
+                  {weekLabel}
+                </span>
+                <button onClick={nextWeek} className="p-1.5 rounded-lg hover:bg-gray-100 shrink-0">
+                  <ChevronRightIcon className="w-4 h-4 text-gray-500" />
+                </button>
+              </div>
+
+              {/* Search + Settings */}
+              <div className="flex items-center gap-1 shrink-0">
+                <button className="p-1.5 rounded-lg hover:bg-gray-100">
+                  <MagnifyingGlassIcon className="w-4 h-4 text-gray-500" />
+                </button>
+                <button className="p-1.5 rounded-lg hover:bg-gray-100">
+                  <Cog6ToothIcon className="w-4 h-4 text-gray-500" />
+                </button>
+              </div>
             </div>
 
-            {/* Hour rows */}
-            {HOUR_SLOTS.map(hour => {
-              const slotStart = parseMinutes(hour);
-              const slotEnd = slotStart + 60;
-              return (
-                <div
-                  key={hour}
-                  className="grid border-t border-gray-50"
-                  style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}
-                >
-                  {/* Hour label */}
-                  <div className="px-2 py-2 text-xs text-gray-400 font-medium text-right leading-none pt-2.5">
-                    {hour}
+            {/* Grid — scrolls horizontally on small screens */}
+            <div className="overflow-x-auto">
+              <div className="min-w-[640px]">
+                {/* Day-column headers */}
+                <div className="grid border-b border-gray-100" style={{ gridTemplateColumns: '52px repeat(7, 1fr)' }}>
+                  <div className="py-3 text-center text-[9px] text-gray-400 font-semibold uppercase tracking-widest">
+                    GMT
                   </div>
-
-                  {/* Day cells */}
-                  {weekDates.map((d, dayIdx) => {
-                    const dayEntries = (entriesByDay.get(toISODate(d)) ?? []).filter(e => {
-                      const start = parseMinutes(e.startTime ?? '00:00');
-                      return start >= slotStart && start < slotEnd;
-                    });
-
+                  {weekDates.map((d, i) => {
+                    const isToday = toISO(d) === todayStr;
                     return (
-                      <div
-                        key={dayIdx}
-                        className="border-l border-gray-100 min-h-[72px] p-1 space-y-1"
-                      >
-                        {dayEntries.map(entry => {
-                          const hexColor = DOCTOR_COLORS[entry.doctorId ?? ''] ?? '#2D9B8A';
-                          return (
-                            <div
-                              key={entry.id}
-                              className="rounded-lg px-2 py-1.5 text-white text-xs"
-                              style={{ backgroundColor: hexColor }}
-                            >
-                              <p className="font-semibold truncate leading-tight">
-                                {entry.patientName}
-                              </p>
-                              <p className="opacity-90 truncate leading-tight">
-                                {(entry.doctorName ?? '').replace('Dr. ', '')}
-                              </p>
-                              <p className="opacity-75 leading-tight">
-                                {entry.startTime}–{entry.endTime}
-                              </p>
-                              <div className="flex items-center gap-1 opacity-80 mt-0.5">
-                                {entry.type === 'ONLINE'
-                                  ? <VideoCameraIcon className="w-3 h-3 shrink-0" />
-                                  : <UserIcon className="w-3 h-3 shrink-0" />}
-                                <span>{entry.type === 'ONLINE' ? 'Online' : 'In-person'}</span>
-                              </div>
-                            </div>
-                          );
-                        })}
+                      <div key={i} className="py-2 text-center border-l border-gray-100">
+                        <p className="text-[9px] font-bold text-gray-400 uppercase tracking-widest">
+                          {DAY_LABELS[i]}
+                        </p>
+                        <div
+                          className="mx-auto mt-1 w-7 h-7 flex items-center justify-center rounded-full text-sm font-bold"
+                          style={isToday
+                            ? { backgroundColor: TEAL, color: '#fff' }
+                            : { color: NAVY }}
+                        >
+                          {d.getUTCDate()}
+                        </div>
                       </div>
                     );
                   })}
                 </div>
-              );
-            })}
-          </div>
-        </div>
 
-        {/* Doctor colour legend */}
-        <div className="px-6 py-4 border-t border-gray-100">
-          <div className="flex flex-wrap gap-x-5 gap-y-2">
-            {doctorLegend.map(doc => (
-              <div key={doc.id} className="flex items-center gap-2">
-                <div
-                  className="w-3 h-3 rounded-full shrink-0"
-                  style={{ backgroundColor: doc.color }}
-                />
-                <span className="text-xs text-gray-600">{doc.name}</span>
+                {/* Hour rows */}
+                {HOUR_SLOTS.map(hour => {
+                  const slotStart = hour * 60;
+                  const slotEnd   = slotStart + 60;
+                  return (
+                    <div
+                      key={hour}
+                      className="grid border-t border-gray-50"
+                      style={{ gridTemplateColumns: '52px repeat(7, 1fr)' }}
+                    >
+                      {/* Time label */}
+                      <div className="pr-2 pt-2.5 text-[10px] text-gray-400 font-medium text-right border-r border-gray-100">
+                        {fmt12(hour)}
+                      </div>
+
+                      {/* Day cells */}
+                      {weekDates.map((d, di) => {
+                        const isToday  = toISO(d) === todayStr;
+                        const daySlots = (entriesByDay.get(toISO(d)) ?? []).filter(e => {
+                          const s = parseMin(e.startTime ?? '00:00');
+                          return s >= slotStart && s < slotEnd;
+                        });
+                        return (
+                          <div
+                            key={di}
+                            className="border-l border-gray-100 min-h-[76px] p-1 space-y-1"
+                            style={isToday ? { backgroundColor: '#EFF6FF40' } : {}}
+                          >
+                            {daySlots.map(entry => {
+                              const { bg, fg } = cardColors(entry.color as string);
+                              const { label, Icon } = typeDisplay(entry.type);
+                              return (
+                                <div
+                                  key={entry.id}
+                                  className="rounded-xl px-2.5 py-2 text-xs cursor-default"
+                                  style={{ backgroundColor: bg, color: fg }}
+                                >
+                                  <p className="font-semibold truncate leading-snug">
+                                    {entry.doctorName ?? entry.patientName}
+                                  </p>
+                                  <div className="flex items-center gap-1 mt-0.5 opacity-80">
+                                    <Icon className="w-3 h-3 shrink-0" />
+                                    <span className="truncate text-[10px]">{label}</span>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
               </div>
-            ))}
+            </div>
+
+            {/* Doctor legend */}
+            <div className="px-5 py-3 border-t border-gray-100 bg-gray-50/40">
+              <div className="flex flex-wrap gap-x-5 gap-y-1.5">
+                {doctorLegend.map(doc => (
+                  <div key={doc.id} className="flex items-center gap-1.5">
+                    <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: doc.color }} />
+                    <span className="text-[11px] text-gray-600">{doc.name}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/hospital/admin/schedule/page.tsx
+++ b/src/app/hospital/admin/schedule/page.tsx
@@ -19,7 +19,6 @@ import type { ScheduleEntry } from '@/types/hospital';
 const NAVY = '#1E3A5F';
 const TEAL = '#38BDF8';
 
-// Pastel card palette keyed to the color field on ScheduleEntry
 const CARD_PALETTE: Record<string, { bg: string; fg: string }> = {
   blue:   { bg: '#EFF6FF', fg: '#1E40AF' },
   green:  { bg: '#F0FDF4', fg: '#166534' },
@@ -38,10 +37,10 @@ function typeDisplay(type?: string): { label: string; Icon: React.ElementType } 
   return { label: 'In Person', Icon: UserIcon };
 }
 
-// ── Date helpers ────────────────────────────────────────────────────────────
+// ── Date helpers ─────────────────────────────────────────────────────────────
 
 function getMondayOfWeek(d: Date): Date {
-  const dow = d.getUTCDay(); // 0=Sun
+  const dow = d.getUTCDay();
   const diff = dow === 0 ? -6 : 1 - dow;
   const m = new Date(d);
   m.setUTCDate(d.getUTCDate() + diff);
@@ -63,51 +62,52 @@ function parseMin(t: string) {
   return h * 60 + m;
 }
 
-function fmt12(h: number) {
-  return h === 12 ? '12 PM' : h > 12 ? `${h - 12} PM` : `${h} AM`;
-}
+// ── Constants ─────────────────────────────────────────────────────────────────
 
-// ── Constants ────────────────────────────────────────────────────────────────
+// 30-minute slots from 08:00 to 14:30 — fixed height, no row inflation
+const HALF_SLOTS: { time: string; label: string; onHour: boolean }[] = [
+  { time: '08:00', label: '8 AM',  onHour: true  },
+  { time: '08:30', label: '',      onHour: false },
+  { time: '09:00', label: '9 AM',  onHour: true  },
+  { time: '09:30', label: '',      onHour: false },
+  { time: '10:00', label: '10 AM', onHour: true  },
+  { time: '10:30', label: '',      onHour: false },
+  { time: '11:00', label: '11 AM', onHour: true  },
+  { time: '11:30', label: '',      onHour: false },
+  { time: '12:00', label: '12 PM', onHour: true  },
+  { time: '12:30', label: '',      onHour: false },
+  { time: '13:00', label: '1 PM',  onHour: true  },
+  { time: '13:30', label: '',      onHour: false },
+  { time: '14:00', label: '2 PM',  onHour: true  },
+  { time: '14:30', label: '',      onHour: false },
+];
 
-const HOUR_SLOTS = [8, 9, 10, 11, 12, 13, 14, 15];
 const DAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December'];
 const DOW_ABBR = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
-// Mock "today" anchored to the demo data week so the calendar pre-loads with data
+// Anchored to Tuesday June 2, 2026 so the week loads Mon Jun 1–Sun Jun 7 with data
 const MOCK_TODAY = new Date('2026-06-02T00:00:00Z');
 
-// ── Component ────────────────────────────────────────────────────────────────
+// ── Component ─────────────────────────────────────────────────────────────────
 
 export default function HospitalAdminSchedulePage() {
   const todayStr = toISO(MOCK_TODAY);
 
-  // Week being viewed
   const [weekStart, setWeekStart] = useState(() => getMondayOfWeek(MOCK_TODAY));
-
-  // Mini-calendar month being shown
-  const [calYear, setCalYear] = useState(MOCK_TODAY.getUTCFullYear());
-  const [calMonth, setCalMonth] = useState(MOCK_TODAY.getUTCMonth());
-
-  // Mobile left-panel visibility
-  const [leftOpen, setLeftOpen] = useState(false);
-
-  // Week / Month tab (Month is visual only — no grid change)
-  const [viewMode, setViewMode] = useState<'week' | 'month'>('week');
+  const [calYear,   setCalYear]   = useState(MOCK_TODAY.getUTCFullYear());
+  const [calMonth,  setCalMonth]  = useState(MOCK_TODAY.getUTCMonth());
+  const [leftOpen,  setLeftOpen]  = useState(false);
+  const [viewMode,  setViewMode]  = useState<'week' | 'month'>('week');
 
   const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart]);
 
   const prevWeek = () => {
-    const d = new Date(weekStart);
-    d.setUTCDate(d.getUTCDate() - 7);
-    setWeekStart(d);
+    const d = new Date(weekStart); d.setUTCDate(d.getUTCDate() - 7); setWeekStart(d);
   };
-
   const nextWeek = () => {
-    const d = new Date(weekStart);
-    d.setUTCDate(d.getUTCDate() + 7);
-    setWeekStart(d);
+    const d = new Date(weekStart); d.setUTCDate(d.getUTCDate() + 7); setWeekStart(d);
   };
 
   const entriesByDay = useMemo(() => {
@@ -121,19 +121,20 @@ export default function HospitalAdminSchedulePage() {
 
   const weekLabel = `${weekDates[0].toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })} – ${weekDates[6].toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}`;
 
-  // Mini-calendar helpers
   const daysInMonth = new Date(Date.UTC(calYear, calMonth + 1, 0)).getUTCDate();
-  const firstDow    = new Date(Date.UTC(calYear, calMonth, 1)).getUTCDay(); // 0=Sun
+  const firstDow    = new Date(Date.UTC(calYear, calMonth, 1)).getUTCDay();
 
   const handleCalDay = (day: number) => {
-    const clicked = new Date(Date.UTC(calYear, calMonth, day));
-    setWeekStart(getMondayOfWeek(clicked));
+    setWeekStart(getMondayOfWeek(new Date(Date.UTC(calYear, calMonth, day))));
   };
 
-  const prevCalMonth = () => calMonth === 0 ? (setCalYear(y => y - 1), setCalMonth(11)) : setCalMonth(m => m - 1);
-  const nextCalMonth = () => calMonth === 11 ? (setCalYear(y => y + 1), setCalMonth(0)) : setCalMonth(m => m + 1);
+  const prevCalMonth = () => calMonth === 0
+    ? (setCalYear(y => y - 1), setCalMonth(11))
+    : setCalMonth(m => m - 1);
+  const nextCalMonth = () => calMonth === 11
+    ? (setCalYear(y => y + 1), setCalMonth(0))
+    : setCalMonth(m => m + 1);
 
-  // Doctor legend
   const doctorLegend = useMemo(() => {
     const seen = new Set<string>();
     return MOCK_SCHEDULE.reduce<{ id: string; name: string; color: string }[]>((acc, e) => {
@@ -146,7 +147,7 @@ export default function HospitalAdminSchedulePage() {
     }, []);
   }, []);
 
-  // ── Left panel ─────────────────────────────────────────────────────────────
+  // ── Left panel ──────────────────────────────────────────────────────────────
 
   const leftPanel = (
     <div className="space-y-3">
@@ -164,14 +165,12 @@ export default function HospitalAdminSchedulePage() {
           </button>
         </div>
 
-        {/* Day-of-week header */}
         <div className="grid grid-cols-7 mb-1">
           {DOW_ABBR.map((d, i) => (
             <div key={i} className="text-center text-[9px] font-semibold text-gray-400">{d}</div>
           ))}
         </div>
 
-        {/* Day grid */}
         <div className="grid grid-cols-7 gap-y-0.5">
           {Array.from({ length: firstDow }, (_, i) => <div key={`e${i}`} />)}
           {Array.from({ length: daysInMonth }, (_, i) => {
@@ -185,8 +184,8 @@ export default function HospitalAdminSchedulePage() {
                 onClick={() => handleCalDay(day)}
                 className="w-6 h-6 mx-auto flex items-center justify-center text-[11px] rounded-full transition-colors hover:opacity-90"
                 style={
-                  isToday  ? { backgroundColor: TEAL,  color: '#fff', fontWeight: 700 } :
-                  isInWeek ? { backgroundColor: NAVY,  color: '#fff', opacity: 0.55 }  :
+                  isToday  ? { backgroundColor: TEAL, color: '#fff', fontWeight: 700 } :
+                  isInWeek ? { backgroundColor: NAVY, color: '#fff', opacity: 0.55 }   :
                              { color: '#374151' }
                 }
               >
@@ -197,7 +196,7 @@ export default function HospitalAdminSchedulePage() {
         </div>
       </div>
 
-      {/* Search for people */}
+      {/* Search */}
       <div className="bg-white rounded-2xl px-3 py-2.5 shadow-sm">
         <div className="relative">
           <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
@@ -209,25 +208,19 @@ export default function HospitalAdminSchedulePage() {
         </div>
       </div>
 
-      {/* Booking pages + My/Other calendars */}
+      {/* Booking pages / calendars */}
       <div className="bg-white rounded-2xl p-4 shadow-sm space-y-4">
         <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">Booking Pages</p>
-
-        {/* My calendars */}
         <div>
           <button className="flex items-center gap-1.5 text-[11px] font-semibold text-gray-700 w-full">
             <ChevronDownIcon className="w-3 h-3 shrink-0" />
             My calendars
           </button>
-          <div className="mt-2 pl-4">
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: TEAL }} />
-              <span className="text-[11px] text-gray-600">Hospital Admin</span>
-            </div>
+          <div className="mt-2 pl-4 flex items-center gap-2">
+            <div className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: TEAL }} />
+            <span className="text-[11px] text-gray-600">Hospital Admin</span>
           </div>
         </div>
-
-        {/* Other calendars */}
         <div>
           <button className="flex items-center gap-1.5 text-[11px] font-semibold text-gray-700 w-full group">
             <PlusIcon className="w-3 h-3 shrink-0 group-hover:text-sky-500 transition-colors" />
@@ -238,11 +231,10 @@ export default function HospitalAdminSchedulePage() {
     </div>
   );
 
-  // ── Render ──────────────────────────────────────────────────────────────────
+  // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
     <div>
-      {/* Mobile panel toggle */}
       <button
         className="lg:hidden mb-4 inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold text-white"
         style={{ backgroundColor: NAVY }}
@@ -253,24 +245,22 @@ export default function HospitalAdminSchedulePage() {
       </button>
 
       <div className="flex gap-5 items-start">
-        {/* Left panel */}
         <aside className={`w-52 shrink-0 ${leftOpen ? 'block' : 'hidden'} lg:block`}>
           {leftPanel}
         </aside>
 
-        {/* Main content */}
         <div className="flex-1 min-w-0 space-y-4">
           {/* Page header */}
-          <div className="rounded-2xl px-8 py-6" style={{ background: '#EBF5FF' }}>
+          <div className="rounded-2xl px-4 py-4 sm:px-8 sm:py-6" style={{ background: '#EBF5FF' }}>
             <div className="flex items-start justify-between flex-wrap gap-3">
               <div>
-                <h1 className="text-3xl font-extrabold tracking-tight" style={{ color: NAVY }}>
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight" style={{ color: NAVY }}>
                   SCHEDULE
                 </h1>
                 <p className="mt-0.5 text-sm text-gray-500">Appointment list &middot; Today</p>
               </div>
               <button
-                className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                className="hidden sm:flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
                 style={{ backgroundColor: TEAL }}
               >
                 Try now
@@ -281,9 +271,8 @@ export default function HospitalAdminSchedulePage() {
 
           {/* Calendar card */}
           <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-            {/* Navigation bar */}
+            {/* Nav bar */}
             <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100 flex-wrap">
-              {/* Week / Month toggle */}
               <div className="flex rounded-lg border border-gray-200 overflow-hidden text-xs font-semibold">
                 <button
                   onClick={() => setViewMode('week')}
@@ -301,12 +290,11 @@ export default function HospitalAdminSchedulePage() {
                 </button>
               </div>
 
-              {/* Arrows + date range */}
               <div className="flex items-center gap-1 flex-1 justify-center min-w-0">
                 <button onClick={prevWeek} className="p-1.5 rounded-lg hover:bg-gray-100 shrink-0">
                   <ChevronLeftIcon className="w-4 h-4 text-gray-500" />
                 </button>
-                <span className="text-xs font-semibold px-1 truncate" style={{ color: NAVY }}>
+                <span className="text-xs font-semibold px-1 truncate max-w-[120px] sm:max-w-none" style={{ color: NAVY }}>
                   {weekLabel}
                 </span>
                 <button onClick={nextWeek} className="p-1.5 rounded-lg hover:bg-gray-100 shrink-0">
@@ -314,7 +302,6 @@ export default function HospitalAdminSchedulePage() {
                 </button>
               </div>
 
-              {/* Search + Settings */}
               <div className="flex items-center gap-1 shrink-0">
                 <button className="p-1.5 rounded-lg hover:bg-gray-100">
                   <MagnifyingGlassIcon className="w-4 h-4 text-gray-500" />
@@ -325,11 +312,14 @@ export default function HospitalAdminSchedulePage() {
               </div>
             </div>
 
-            {/* Grid — scrolls horizontally on small screens */}
+            {/* Grid */}
             <div className="overflow-x-auto">
               <div className="min-w-[640px]">
                 {/* Day-column headers */}
-                <div className="grid border-b border-gray-100" style={{ gridTemplateColumns: '52px repeat(7, 1fr)' }}>
+                <div
+                  className="grid border-b border-gray-100"
+                  style={{ gridTemplateColumns: '52px repeat(7, 1fr)' }}
+                >
                   <div className="py-3 text-center text-[9px] text-gray-400 font-semibold uppercase tracking-widest">
                     GMT
                   </div>
@@ -353,45 +343,45 @@ export default function HospitalAdminSchedulePage() {
                   })}
                 </div>
 
-                {/* Hour rows */}
-                {HOUR_SLOTS.map(hour => {
-                  const slotStart = hour * 60;
-                  const slotEnd   = slotStart + 60;
+                {/* 30-minute slot rows — fixed h-14 so no row ever inflates */}
+                {HALF_SLOTS.map(slot => {
+                  const slotMin = parseMin(slot.time);
                   return (
                     <div
-                      key={hour}
-                      className="grid border-t border-gray-50"
-                      style={{ gridTemplateColumns: '52px repeat(7, 1fr)' }}
+                      key={slot.time}
+                      className="grid"
+                      style={{ gridTemplateColumns: '52px repeat(7, 1fr)', height: 56 }}
                     >
-                      {/* Time label */}
-                      <div className="pr-2 pt-2.5 text-[10px] text-gray-400 font-medium text-right border-r border-gray-100">
-                        {fmt12(hour)}
+                      {/* Time label — only on the :00 mark */}
+                      <div
+                        className={`flex items-start justify-end pr-2 pt-1.5 text-[10px] font-medium text-gray-400 border-r border-gray-100 ${slot.onHour ? 'border-t border-gray-100' : 'border-t border-gray-50'}`}
+                      >
+                        {slot.label}
                       </div>
 
                       {/* Day cells */}
                       {weekDates.map((d, di) => {
                         const isToday  = toISO(d) === todayStr;
-                        const daySlots = (entriesByDay.get(toISO(d)) ?? []).filter(e => {
+                        const dayEntry = (entriesByDay.get(toISO(d)) ?? []).find(e => {
                           const s = parseMin(e.startTime ?? '00:00');
-                          return s >= slotStart && s < slotEnd;
+                          return s >= slotMin && s < slotMin + 30;
                         });
                         return (
                           <div
                             key={di}
-                            className="border-l border-gray-100 min-h-[76px] p-1 space-y-1"
+                            className={`border-l border-gray-100 p-1 ${slot.onHour ? 'border-t border-gray-100' : 'border-t border-gray-50'}`}
                             style={isToday ? { backgroundColor: '#EFF6FF40' } : {}}
                           >
-                            {daySlots.map(entry => {
-                              const { bg, fg } = cardColors(entry.color as string);
-                              const { label, Icon } = typeDisplay(entry.type);
+                            {dayEntry && (() => {
+                              const { bg, fg } = cardColors(dayEntry.color as string);
+                              const { label, Icon } = typeDisplay(dayEntry.type);
                               return (
                                 <div
-                                  key={entry.id}
-                                  className="rounded-xl px-2.5 py-2 text-xs cursor-default"
+                                  className="rounded-xl px-2 py-1.5 text-xs cursor-default h-full"
                                   style={{ backgroundColor: bg, color: fg }}
                                 >
-                                  <p className="font-semibold truncate leading-snug">
-                                    {entry.doctorName ?? entry.patientName}
+                                  <p className="font-semibold truncate leading-snug text-[11px]">
+                                    {dayEntry.doctorName ?? dayEntry.patientName}
                                   </p>
                                   <div className="flex items-center gap-1 mt-0.5 opacity-80">
                                     <Icon className="w-3 h-3 shrink-0" />
@@ -399,7 +389,7 @@ export default function HospitalAdminSchedulePage() {
                                   </div>
                                 </div>
                               );
-                            })}
+                            })()}
                           </div>
                         );
                       })}

--- a/src/mock/hospital/schedule.ts
+++ b/src/mock/hospital/schedule.ts
@@ -15,31 +15,30 @@ export const DOCTOR_COLORS: Record<string, string> = {
 // Current week: June 2 – 8, 2026
 export const MOCK_SCHEDULE: ScheduleEntry[] = [
   // Monday June 2
-  { id: 'sch-001', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni', patientName: 'Jean Bosco Niyonzima', date: '2026-06-02', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'IN_PERSON', color: 'blue' },
-  { id: 'sch-002', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana', patientName: 'Claudine Uwimana', date: '2026-06-02', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON', color: 'green' },
-  { id: 'sch-003', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana', patientName: 'Thierry Nkurunziza', date: '2026-06-02', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'IN_PERSON', color: 'purple' },
-  { id: 'sch-004', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire', patientName: 'Odette Umuraza', date: '2026-06-02', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'ONLINE', color: 'orange' },
-  { id: 'sch-005', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni', patientName: 'Aimable Tuyishimire', date: '2026-06-02', startTime: '14:00', endTime: '14:30', time: '02:00 - 02:30', type: 'IN_PERSON', color: 'blue' },
+  { id: 'sch-001', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Jean Bosco Niyonzima',   date: '2026-06-02', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'VIDEO_CALL', color: 'blue' },
+  { id: 'sch-002', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Claudine Uwimana',       date: '2026-06-02', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
+  { id: 'sch-003', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',     patientName: 'Thierry Nkurunziza',     date: '2026-06-02', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'AUDIO_CALL', color: 'purple' },
+  { id: 'sch-004', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Odette Umuraza',         date: '2026-06-02', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
+  { id: 'sch-005', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Aimable Tuyishimire',    date: '2026-06-02', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'blue' },
 
   // Tuesday June 3
-  { id: 'sch-006', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Emmanuel Gakwerere', date: '2026-06-03', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON', color: 'green' },
-  { id: 'sch-007', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana', patientName: 'Gaspard Bizimana', date: '2026-06-03', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'IN_PERSON', color: 'blue' },
-  { id: 'sch-008', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana', patientName: 'Marie Claire Mukasonga', date: '2026-06-03', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON', color: 'purple' },
-  { id: 'sch-009', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha', patientName: 'Faustin Niyomugabo', date: '2026-06-03', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'ONLINE', color: 'orange' },
+  { id: 'sch-006', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Emmanuel Gakwerere',   date: '2026-06-03', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
+  { id: 'sch-007', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Gaspard Bizimana',     date: '2026-06-03', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'AUDIO_CALL', color: 'blue' },
+  { id: 'sch-008', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',      patientName: 'Marie Claire Mukasonga', date: '2026-06-03', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON',  color: 'purple' },
+  { id: 'sch-009', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',   patientName: 'Faustin Niyomugabo',   date: '2026-06-03', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
 
   // Wednesday June 4
-  { id: 'sch-010', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni', patientName: 'Alphonsine Umutoni', date: '2026-06-04', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON', color: 'blue' },
-  { id: 'sch-011', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire', patientName: 'Fidele Nsengimana', date: '2026-06-04', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'ONLINE', color: 'orange' },
-  { id: 'sch-012', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha', patientName: 'Joselyne Uwizeyimana', date: '2026-06-04', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'IN_PERSON', color: 'purple' },
+  { id: 'sch-010', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Alphonsine Umutoni',    date: '2026-06-04', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'blue' },
+  { id: 'sch-011', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Fidele Nsengimana',     date: '2026-06-04', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
+  { id: 'sch-012', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',  patientName: 'Joselyne Uwizeyimana',  date: '2026-06-04', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'IN_PERSON',  color: 'purple' },
 
   // Thursday June 5
-  { id: 'sch-013', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana', patientName: 'Sylvie Nzeyimana', date: '2026-06-05', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'IN_PERSON', color: 'green' },
-  { id: 'sch-014', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana', patientName: 'Placide Nzabonimana', date: '2026-06-05', startTime: '08:00', endTime: '08:30', time: '08:00 - 08:30', type: 'IN_PERSON', color: 'purple' },
-  { id: 'sch-015', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Vestine Nyiranzeyimana', date: '2026-06-05', startTime: '14:00', endTime: '14:30', time: '02:00 - 02:30', type: 'IN_PERSON', color: 'green' },
+  { id: 'sch-013', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Sylvie Nzeyimana',      date: '2026-06-05', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'AUDIO_CALL', color: 'green' },
+  { id: 'sch-014', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',     patientName: 'Placide Nzabonimana',   date: '2026-06-05', startTime: '08:00', endTime: '08:30', time: '08:00 - 08:30', type: 'IN_PERSON',  color: 'purple' },
+  { id: 'sch-015', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Vestine Nyiranzeyimana', date: '2026-06-05', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
 
   // Friday June 6
-  { id: 'sch-016', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni', patientName: 'Regis Habineza', date: '2026-06-06', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'IN_PERSON', color: 'blue' },
-  { id: 'sch-017', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire', patientName: 'Chantal Mukabutera', date: '2026-06-06', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON', color: 'orange' },
-  { id: 'sch-018', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana', patientName: 'Immaculee Uwera', date: '2026-06-06', startTime: '14:00', endTime: '14:30', time: '02:00 - 02:30', type: 'IN_PERSON', color: 'green' },
+  { id: 'sch-016', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Regis Habineza',        date: '2026-06-06', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'VIDEO_CALL', color: 'blue' },
+  { id: 'sch-017', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Chantal Mukabutera',    date: '2026-06-06', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
+  { id: 'sch-018', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Immaculee Uwera',       date: '2026-06-06', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
 ];
-

--- a/src/mock/hospital/schedule.ts
+++ b/src/mock/hospital/schedule.ts
@@ -12,33 +12,34 @@ export const DOCTOR_COLORS: Record<string, string> = {
   'doc-007': '#DB2777', // pink   — Beata Mukamugisha
 };
 
-// Current week: June 2 – 8, 2026
+// Week: Monday June 1 – Sunday June 7, 2026
+// (June 1 2026 is confirmed Monday; mock "today" = Tuesday June 2)
 export const MOCK_SCHEDULE: ScheduleEntry[] = [
-  // Monday June 2
-  { id: 'sch-001', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Jean Bosco Niyonzima',   date: '2026-06-02', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'VIDEO_CALL', color: 'blue' },
-  { id: 'sch-002', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Claudine Uwimana',       date: '2026-06-02', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
-  { id: 'sch-003', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',     patientName: 'Thierry Nkurunziza',     date: '2026-06-02', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'AUDIO_CALL', color: 'purple' },
-  { id: 'sch-004', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Odette Umuraza',         date: '2026-06-02', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
-  { id: 'sch-005', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Aimable Tuyishimire',    date: '2026-06-02', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'blue' },
+  // Monday June 1
+  { id: 'sch-001', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',        patientName: 'Jean Bosco Niyonzima',    date: '2026-06-01', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'VIDEO_CALL', color: 'blue' },
+  { id: 'sch-002', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Claudine Uwimana',        date: '2026-06-01', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
+  { id: 'sch-003', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',      patientName: 'Thierry Nkurunziza',      date: '2026-06-01', startTime: '10:30', endTime: '11:00', time: '10:30 - 11:00', type: 'AUDIO_CALL', color: 'purple' },
+  { id: 'sch-004', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',    patientName: 'Odette Umuraza',          date: '2026-06-01', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
+  { id: 'sch-005', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',        patientName: 'Aimable Tuyishimire',     date: '2026-06-01', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'blue' },
 
-  // Tuesday June 3
-  { id: 'sch-006', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Emmanuel Gakwerere',   date: '2026-06-03', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
-  { id: 'sch-007', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Gaspard Bizimana',     date: '2026-06-03', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'AUDIO_CALL', color: 'blue' },
-  { id: 'sch-008', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',      patientName: 'Marie Claire Mukasonga', date: '2026-06-03', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON',  color: 'purple' },
-  { id: 'sch-009', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',   patientName: 'Faustin Niyomugabo',   date: '2026-06-03', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
+  // Tuesday June 2
+  { id: 'sch-006', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Emmanuel Gakwerere',      date: '2026-06-02', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'green' },
+  { id: 'sch-007', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Gaspard Bizimana',        date: '2026-06-02', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'AUDIO_CALL', color: 'blue' },
+  { id: 'sch-008', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',      patientName: 'Marie Claire Mukasonga',  date: '2026-06-02', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON',  color: 'purple' },
+  { id: 'sch-009', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',   patientName: 'Faustin Niyomugabo',      date: '2026-06-02', startTime: '11:00', endTime: '11:30', time: '11:00 - 11:30', type: 'VIDEO_CALL', color: 'orange' },
 
-  // Wednesday June 4
-  { id: 'sch-010', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Alphonsine Umutoni',    date: '2026-06-04', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'blue' },
-  { id: 'sch-011', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Fidele Nsengimana',     date: '2026-06-04', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
-  { id: 'sch-012', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',  patientName: 'Joselyne Uwizeyimana',  date: '2026-06-04', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'IN_PERSON',  color: 'purple' },
+  // Wednesday June 3
+  { id: 'sch-010', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',        patientName: 'Alphonsine Umutoni',      date: '2026-06-03', startTime: '09:00', endTime: '09:30', time: '09:00 - 09:30', type: 'IN_PERSON',  color: 'blue' },
+  { id: 'sch-011', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',    patientName: 'Fidele Nsengimana',       date: '2026-06-03', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
+  { id: 'sch-012', doctorId: 'doc-007', doctorName: 'Dr. Beata Mukamugisha',   patientName: 'Joselyne Uwizeyimana',    date: '2026-06-03', startTime: '11:30', endTime: '12:00', time: '11:30 - 12:00', type: 'IN_PERSON',  color: 'purple' },
 
-  // Thursday June 5
-  { id: 'sch-013', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Sylvie Nzeyimana',      date: '2026-06-05', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'AUDIO_CALL', color: 'green' },
-  { id: 'sch-014', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',     patientName: 'Placide Nzabonimana',   date: '2026-06-05', startTime: '08:00', endTime: '08:30', time: '08:00 - 08:30', type: 'IN_PERSON',  color: 'purple' },
-  { id: 'sch-015', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Vestine Nyiranzeyimana', date: '2026-06-05', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
+  // Thursday June 4
+  { id: 'sch-013', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Sylvie Nzeyimana',        date: '2026-06-04', startTime: '08:30', endTime: '09:00', time: '08:30 - 09:00', type: 'AUDIO_CALL', color: 'green' },
+  { id: 'sch-014', doctorId: 'doc-003', doctorName: 'Dr. Diane Mukamana',      patientName: 'Placide Nzabonimana',     date: '2026-06-04', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'IN_PERSON',  color: 'purple' },
+  { id: 'sch-015', doctorId: 'doc-006', doctorName: 'Dr. Celestin Rudasingwa', patientName: 'Vestine Nyiranzeyimana',  date: '2026-06-04', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
 
-  // Friday June 6
-  { id: 'sch-016', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',       patientName: 'Regis Habineza',        date: '2026-06-06', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'VIDEO_CALL', color: 'blue' },
-  { id: 'sch-017', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',   patientName: 'Chantal Mukabutera',    date: '2026-06-06', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
-  { id: 'sch-018', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',   patientName: 'Immaculee Uwera',       date: '2026-06-06', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
+  // Friday June 5
+  { id: 'sch-016', doctorId: 'doc-001', doctorName: 'Dr. Alice Mutoni',        patientName: 'Regis Habineza',          date: '2026-06-05', startTime: '09:30', endTime: '10:00', time: '09:30 - 10:00', type: 'VIDEO_CALL', color: 'blue' },
+  { id: 'sch-017', doctorId: 'doc-005', doctorName: 'Dr. Solange Ingabire',    patientName: 'Chantal Mukabutera',      date: '2026-06-05', startTime: '10:00', endTime: '10:30', time: '10:00 - 10:30', type: 'AUDIO_CALL', color: 'orange' },
+  { id: 'sch-018', doctorId: 'doc-002', doctorName: 'Dr. Patrick Habimana',    patientName: 'Immaculee Uwera',         date: '2026-06-05', startTime: '14:00', endTime: '14:30', time: '14:00 - 14:30', type: 'IN_PERSON',  color: 'green' },
 ];


### PR DESCRIPTION
## Summary

- **Appointments page** (`/hospital/admin/appointments`): filterable table with search input, All Doctors / All Departments dropdowns, and date picker; department coloured pills; status coloured badges (Confirmed / Pending / Cancelled / Ready / Completed); edit and delete icon buttons; UTC-safe date formatting; horizontal scroll on mobile.
- **Schedule page** (`/hospital/admin/schedule`): weekly calendar grid with prev/next navigation, appointment cards coloured by doctor via `DOCTOR_COLORS`, in-person vs online type icons, doctor colour legend at bottom; UTC-safe date arithmetic (`setUTCDate`/`getUTCDate`); horizontal scroll below 640 px.
- Appointments nav entry was already present in `HospitalSidebar.tsx` on dev — no sidebar change needed.

## Design verification

| Item | Status |
|------|--------|
| Figma frame | Node `887:186` ("Desktop - 4") — confirmed HospitalAdmin portal (sidebar shows Staff Management, Departments, Appointments, Schedule, Finance, Inventory, Reports) |
| Appointments page | Matches full-res `figma_appointments.png` — title, subtitle, all 6 columns, badge colours |
| Schedule frame | Resolved via `get_metadata` subagent; weekly grid is an adaptation of the Figma admin canvas overview — no conflicting admin schedule frame exists |
| Edit/Delete buttons | Intentionally non-functional placeholders; no detail/modal frame was present in the Figma design |


## Test plan

- [ ] `/hospital/admin/appointments` renders at 1440 px: filter bar, all 6 columns, coloured pills/badges
- [ ] Appointments: search, doctor filter, dept filter, date filter, Reset all work
- [ ] `/hospital/admin/schedule` renders at 1440 px: weekly grid, appointment cards, doctor legend
- [ ] Schedule: prev/next week navigation moves the grid correctly
- [ ] Both pages: no horizontal overflow at 390 px (table/grid scrolls within container)
- [ ] `npx tsc --noEmit` — zero errors on both pages