### PR TITLE
feat: adding the message and settings pages

### DIFF
--- a/src/app/hospital/nurse/messages/page.tsx
+++ b/src/app/hospital/nurse/messages/page.tsx
@@ -1,3 +1,240 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    PaperAirplaneIcon,
+    MagnifyingGlassIcon,
+    ChatBubbleLeftRightIcon,
+    ChatBubbleOvalLeftEllipsisIcon,
+    ClockIcon
+} from '@heroicons/react/24/outline';
+import { MOCK_CONVERSATIONS } from '@/mock/hospital/messages';
+import { Conversation, Message } from '@/types/hospital';
+
+const NAVY = '#1E3A5F';
+const TEAL = '#38BDF8';
+
+const formatTime = (ts: string) => {
+    const d = new Date(ts);
+    return isNaN(d.getTime())
+        ? ts
+        : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
 export default function NurseMessagesPage() {
-  return <div />;
+    const { t } = useTranslation();
+    const [conversations, setConversations] = useState<Conversation[]>(MOCK_CONVERSATIONS);
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const [inputText, setInputText] = useState('');
+    const [search, setSearch] = useState('');
+
+    const activeConversation = conversations.find(c => c.id === activeId) || null;
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    const filteredConversations = conversations.filter(c =>
+        c.senderName.toLowerCase().includes(search.toLowerCase()) ||
+        c.role.toLowerCase().includes(search.toLowerCase())
+    );
+
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [activeConversation?.messages]);
+
+    const handleSendMessage = (e?: React.FormEvent) => {
+        if (e) e.preventDefault();
+        if (!inputText.trim() || !activeId) return;
+
+        const newMessage: Message = {
+            id: Date.now().toString(),
+            text: inputText,
+            direction: 'SENT',
+            timestamp: new Date().toISOString()
+        };
+
+        setConversations(prev => prev.map(c => {
+            if (c.id === activeId) {
+                return {
+                    ...c,
+                    messages: [...c.messages, newMessage],
+                    lastMessage: inputText,
+                    timestamp: new Date().toISOString()
+                };
+            }
+            return c;
+        }));
+
+        setInputText('');
+    };
+
+    return (
+        <div className="max-w-7xl mx-auto h-[calc(100vh-112px)] flex flex-col gap-4">
+            {/* ── Page Hero ── */}
+            <div
+                className="rounded-2xl px-6 sm:px-10 py-8 sm:py-10 flex items-center justify-between shrink-0"
+                style={{ background: '#EBF5FF' }}
+            >
+                <div>
+                    <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>
+                        {t('hospital.messages') || 'Messages'}
+                    </h1>
+                    <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+                        Check your conversations with other nurses and doctors
+                    </p>
+                </div>
+                <div className="opacity-20 shrink-0" style={{ color: NAVY }}>
+                    <ChatBubbleLeftRightIcon className="w-16 h-16 sm:w-20 sm:h-20" />
+                </div>
+            </div>
+
+            <div className="flex-1 flex gap-6 overflow-hidden min-h-0">
+                {/* ── Left Panel: Conversation List ── */}
+                <div className="w-80 lg:w-96 bg-white rounded-3xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
+                    <div className="p-5 border-b border-gray-100 bg-gray-50/50">
+                        <div className="relative">
+                            <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                            <input
+                                type="text"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                placeholder="Search conversations..."
+                                className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto">
+                        {filteredConversations.length === 0 ? (
+                            <div className="p-8 text-center text-sm text-gray-400">
+                                No conversations found.
+                            </div>
+                        ) : (
+                            <ul className="divide-y divide-gray-50">
+                                {filteredConversations.map((conv) => (
+                                    <li
+                                        key={conv.id}
+                                        onClick={() => setActiveId(conv.id)}
+                                        className={`p-4 cursor-pointer transition-all hover:bg-gray-50 group ${activeId === conv.id ? 'bg-gray-100' : ''
+                                            }`}
+                                    >
+                                        <div className="flex items-start gap-4">
+                                            <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-100 flex items-center justify-center text-blue-700 font-bold text-lg shadow-inner shrink-0 group-hover:scale-105 transition-transform">
+                                                {conv.initials}
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <div className="flex justify-between items-center mb-0.5">
+                                                    <h3 className="text-sm font-bold text-gray-900 truncate">{conv.senderName}</h3>
+                                                    <span className="text-[10px] font-medium text-gray-400">{formatTime(conv.timestamp)}</span>
+                                                </div>
+                                                <p className="text-xs font-semibold text-blue-600 mb-1">{conv.role}</p>
+                                                <p className="text-xs text-gray-500 truncate">{conv.lastMessage}</p>
+                                            </div>
+                                            {(conv.unreadCount ?? 0) > 0 && (
+                                                <div className="w-5 h-5 rounded-full bg-blue-600 text-white text-[10px] flex items-center justify-center font-bold">
+                                                    {conv.unreadCount}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </div>
+                </div>
+
+                {/* ── Right Panel: Message Thread ── */}
+                <div className="flex-1 bg-white rounded-3xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
+                    {!activeConversation ? (
+                        /* Empty state — no conversation selected yet */
+                        <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
+                            <div className="w-20 h-20 rounded-full bg-blue-50 flex items-center justify-center mb-5">
+                                <ChatBubbleOvalLeftEllipsisIcon className="w-10 h-10 text-blue-300" />
+                            </div>
+                            <h2 className="text-lg font-bold text-gray-900">Your Messages</h2>
+                            <p className="text-sm text-gray-500 mt-1 max-w-xs">
+                                Select and search specific messages from fellow nurses and doctors.
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            {/* Header */}
+                            <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+                                <div className="flex items-center gap-4">
+                                    <div className="w-10 h-10 rounded-xl bg-blue-50 flex items-center justify-center text-blue-600 font-bold">
+                                        {activeConversation.initials}
+                                    </div>
+                                    <div>
+                                        <h2 className="text-base font-bold text-gray-900">{activeConversation.senderName}</h2>
+                                        <p className="text-xs font-medium text-gray-500">{activeConversation.role}</p>
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                                    <span className="text-xs font-medium text-gray-400">Online</span>
+                                </div>
+                            </div>
+
+                            {/* Messages */}
+                            <div className="flex-1 overflow-y-auto p-6 space-y-6 bg-gray-50/30">
+                                {activeConversation.messages.length === 0 ? (
+                                    <div className="h-full flex flex-col items-center justify-center text-center gap-2">
+                                        <ChatBubbleLeftRightIcon className="w-12 h-12 text-gray-200" />
+                                        <p className="text-sm font-semibold text-gray-500">No messages yet</p>
+                                        <p className="text-xs text-gray-400">Start the conversation by sending a message below.</p>
+                                    </div>
+                                ) : (
+                                    <>
+                                        {activeConversation.messages.map((msg) => (
+                                            <div
+                                                key={msg.id}
+                                                className={`flex ${msg.direction === 'SENT' ? 'justify-end' : 'justify-start'}`}
+                                            >
+                                                <div className={`max-w-[70%] group flex flex-col ${msg.direction === 'SENT' ? 'items-end' : 'items-start'}`}>
+                                                    <div
+                                                        className={`px-5 py-3 rounded-2xl shadow-sm text-sm leading-relaxed ${msg.direction === 'SENT'
+                                                            ? 'bg-blue-600 text-white rounded-tr-none'
+                                                            : 'bg-white text-gray-800 border border-gray-100 rounded-tl-none'
+                                                            }`}
+                                                    >
+                                                        {msg.text}
+                                                    </div>
+                                                    <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                                                        <ClockIcon className="w-3 h-3 text-gray-400" />
+                                                        <span className="text-[10px] font-medium text-gray-400">{formatTime(msg.timestamp)}</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ))}
+                                        <div ref={messagesEndRef} />
+                                    </>
+                                )}
+                            </div>
+
+                            {/* Input */}
+                            <div className="p-4 border-t border-gray-100">
+                                <form
+                                    onSubmit={handleSendMessage}
+                                    className="flex items-center gap-3 bg-gray-50 p-2 rounded-2xl border border-gray-200 focus-within:ring-2 focus-within:ring-blue-500/20 focus-within:border-blue-500/50 transition-all"
+                                >
+                                    <input
+                                        value={inputText}
+                                        onChange={(e) => setInputText(e.target.value)}
+                                        placeholder="Type your message here..."
+                                        className="flex-1 bg-transparent border-none focus:ring-0 text-sm py-2 px-4 placeholder:text-gray-400 text-gray-700 font-medium"
+                                    />
+                                    <button
+                                        type="submit"
+                                        className="p-3 bg-blue-600 text-white rounded-xl shadow-lg shadow-blue-500/30 hover:bg-blue-700 transition-all active:scale-95 disabled:opacity-50"
+                                        disabled={!inputText.trim()}
+                                    >
+                                        <PaperAirplaneIcon className="w-5 h-5 -rotate-45 -translate-y-0.5 translate-x-0.5" />
+                                    </button>
+                                </form>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/app/hospital/nurse/settings/page.tsx
+++ b/src/app/hospital/nurse/settings/page.tsx
@@ -1,3 +1,275 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { Settings, CheckCircle, Pencil, Camera } from 'lucide-react';
+import { MOCK_HOSPITAL_SETTINGS } from '@/mock/hospital/settings';
+
+const NAVY     = '#1E3A5F';
+const TEAL     = '#38BDF8';
+const GRADIENT = 'linear-gradient(90deg, #0284C7 0%, #38BDF8 100%)';
+
+const mockNurse = {
+  name:          'Claudine Umutoni',
+  initials:      'CU',
+  role:          'Registered Nurse',
+  email:         'claudine.umutoni@evuze.rw',
+  phone:         '+250789384713',
+  hospital:      MOCK_HOSPITAL_SETTINGS.hospitalName,
+  specialization:'Medical Surgery',
+  licenseNumber: 'xxxx-xxxx-xxxx',
+  workingHours:  '10 AM - 5PM',
+  status:        'APPROVED' as const,
+};
+
+type Tab = 'profile' | 'department' | 'changePassword';
+
+const inputCls =
+  'w-full border border-gray-200 rounded-xl px-4 text-sm text-gray-700 outline-none ' +
+  'focus:ring-2 disabled:bg-white disabled:text-gray-600 transition-all ' +
+  'min-h-11';
+
+const labelCls = 'block text-xs font-bold text-gray-600 uppercase tracking-widest mb-2';
+
 export default function NurseSettingsPage() {
-  return <div />;
+  const [activeTab,      setActiveTab]      = useState<Tab>('profile');
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [profileForm,    setProfileForm]    = useState({
+    fullName:       mockNurse.name,
+    email:          mockNurse.email,
+    phone:          mockNurse.phone,
+    specialization: mockNurse.specialization,
+  });
+  const [passwordForm, setPasswordForm] = useState({
+    current: '',
+    newPass: '',
+    confirm: '',
+  });
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setAvatarUrl(URL.createObjectURL(file));
+  };
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'profile',        label: 'Profile' },
+    { key: 'department',     label: 'Department' },
+    { key: 'changePassword', label: 'Change Password' },
+  ];
+
+  return (
+    <div className="space-y-8">
+
+      {/* Hero header */}
+      <div
+        className="rounded-2xl px-6 sm:px-10 py-8 sm:py-10 flex items-center justify-between"
+        style={{ background: '#EBF5FF' }}
+      >
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>Settings</h1>
+          <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+            Manage your account and preferences
+          </p>
+        </div>
+        <div className="relative opacity-20 shrink-0" style={{ color: NAVY }}>
+          <Settings size={72} />
+          <div className="absolute -bottom-1 -right-1 bg-white rounded-full p-1">
+            <Pencil size={20} style={{ color: NAVY }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className="shrink-0 whitespace-nowrap px-5 py-2 rounded-full text-sm font-semibold transition-all min-h-[38px]"
+            style={
+              activeTab === tab.key
+                ? { background: GRADIENT, color: '#fff' }
+                : { background: '#fff', color: '#6b7280', border: '1px solid #d1d5db' }
+            }
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+
+        {/* Nurse card */}
+        <div className="w-full lg:w-72 lg:shrink-0 bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-7 flex flex-col items-center text-center">
+          <div className="relative mb-4">
+            <div
+              className="w-20 h-20 sm:w-24 sm:h-24 rounded-full flex items-center justify-center text-white text-2xl sm:text-3xl font-bold overflow-hidden"
+              style={{ background: GRADIENT }}
+            >
+              {avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={avatarUrl} alt={mockNurse.name} className="w-full h-full object-cover" />
+              ) : (
+                mockNurse.initials
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Change profile photo"
+              className="absolute -bottom-1 -right-1 w-8 h-8 rounded-full bg-white shadow-md border border-gray-100 flex items-center justify-center hover:bg-gray-50 transition-colors"
+            >
+              <Camera size={15} style={{ color: NAVY }} />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleAvatarChange}
+              className="hidden"
+            />
+          </div>
+          <p className="font-bold text-base sm:text-lg" style={{ color: NAVY }}>{mockNurse.name}</p>
+          <p className="text-sm text-gray-500 mt-0.5">{mockNurse.role}</p>
+
+          <div className="w-full border-t border-gray-100 my-5" />
+
+          <div className="w-full text-left space-y-4">
+            {[
+              { label: 'Email',        value: mockNurse.email,    extra: 'break-all' },
+              { label: 'Phone Number', value: mockNurse.phone,    extra: '' },
+              { label: 'Hospital',     value: mockNurse.hospital, teal: true },
+            ].map(({ label, value, extra, teal }) => (
+              <div key={label}>
+                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-0.5">{label}</p>
+                <p
+                  className={`text-sm ${extra} ${teal ? 'font-semibold' : 'text-gray-700'}`}
+                  style={teal ? { color: TEAL } : {}}
+                >
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Tab content */}
+        <div className="flex-1 w-full space-y-6">
+
+          {/* Profile Tab*/}
+          {activeTab === 'profile' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-base font-bold" style={{ color: NAVY }}>Profile Information</h2>
+                  <button
+                    onClick={() => setEditingProfile(!editingProfile)}
+                    className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold text-white transition-all hover:opacity-90 min-h-11"
+                    style={{ background: GRADIENT }}
+                  >
+                    <Pencil size={14} />
+                    {editingProfile ? 'Cancel' : 'Edit Profile'}
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+                  {[
+                    { label: 'Full Name',      key: 'fullName'       as const },
+                    { label: 'Email',          key: 'email'          as const },
+                    { label: 'Phone Number',   key: 'phone'          as const },
+                    { label: 'Specialization', key: 'specialization' as const },
+                  ].map(({ label, key }) => (
+                    <div key={key}>
+                      <label className={labelCls}>{label}</label>
+                      <input
+                        type="text"
+                        value={profileForm[key]}
+                        disabled={!editingProfile}
+                        onChange={(e) => setProfileForm((p) => ({ ...p, [key]: e.target.value }))}
+                        className={inputCls}
+                        style={{ '--tw-ring-color': TEAL } as React.CSSProperties}
+                      />
+                    </div>
+                  ))}
+                </div>
+
+              {editingProfile && (
+                <div className="mt-6 flex justify-end">
+                  <button
+                    onClick={() => setEditingProfile(false)}
+                    className="w-full sm:w-auto px-8 min-h-11 rounded-xl text-white text-sm font-semibold hover:opacity-90 transition-all"
+                    style={{ background: GRADIENT }}
+                  >
+                    Save Changes
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Department Tab */}
+          {activeTab === 'department' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-base font-bold" style={{ color: NAVY }}>Department Details</h2>
+                <span className="flex items-center gap-1.5 text-sm font-semibold text-emerald-600">
+                  <CheckCircle size={15} />
+                  APPROVED
+                </span>
+              </div>
+              <div className="space-y-5">
+                {[
+                  { label: 'Specialization', value: mockNurse.specialization },
+                  { label: 'License number', value: mockNurse.licenseNumber },
+                  { label: 'Hospital',       value: mockNurse.hospital },
+                  { label: 'Working hours',  value: mockNurse.workingHours },
+                ].map(({ label, value }) => (
+                  <div key={label} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-6 text-sm">
+                    <span className="sm:w-40 text-gray-500 font-medium shrink-0">{label}</span>
+                    <span className="font-semibold text-gray-800">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* CHANGE PASSWORD TAB */}
+          {activeTab === 'changePassword' && (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-md p-6 sm:p-8">
+              <h2 className="text-base font-bold mb-6" style={{ color: NAVY }}>Change Password</h2>
+              <div className="space-y-5">
+                {[
+                  { label: 'Current Password',     key: 'current' as const },
+                  { label: 'New Password',         key: 'newPass' as const },
+                  { label: 'Confirm New Password', key: 'confirm' as const },
+                ].map(({ label, key }) => (
+                  <div key={key}>
+                    <label className={labelCls}>{label}</label>
+                    <input
+                      type="password"
+                      value={passwordForm[key]}
+                      onChange={(e) => setPasswordForm((p) => ({ ...p, [key]: e.target.value }))}
+                      className={inputCls}
+                      style={{ '--tw-ring-color': TEAL } as React.CSSProperties}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="mt-7">
+                {/* Full-width on mobile, auto-width on sm+ */}
+                <button
+                  className="w-full sm:w-auto sm:px-10 min-h-11 rounded-xl text-white text-sm font-semibold hover:opacity-90 transition-all"
+                  style={{ background: GRADIENT }}
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          )}
+
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
This PR implements the Nurse portal Messages and Settings pages, which previously had no UI. Both pages are built with mock data only and match the Figma designs.

## Changes
- **`src/app/hospital/nurse/messages/page.tsx`** — two-panel conversation layout (list left, chat right); reuses `MOCK_CONVERSATIONS` from `src/mock/hospital/messages.ts` (not duplicated); defaults to empty state until a conversation is selected; selected row styled with subtle gray (`bg-gray-100`), no blue border; hero header matches the Settings page style (flat `#EBF5FF` bg, `NAVY`/`TEAL` constants, icon right-aligned); panels fill the true content area (`calc(100vh - 112px)`) so no dead space below
- **`src/app/hospital/nurse/settings/page.tsx`** — Profile / Department / Change Password tabs pre-filled from `MOCK_HOSPITAL_SETTINGS`; working edit-photo icon on the avatar (file picker → live preview via `URL.createObjectURL`); notification toggles removed as they are not in the Figma design (to be proposed separately)

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting
- [x] Hospital (Nurse portal only)

## How to test
1. Visit `/hospital/nurse/messages`: conversation list appears on the left; right panel shows empty state by default
2. Click any conversation, the messages load in the chat panel
3. Type in the input and send: message appends as SENT
4. Visit `/hospital/nurse/settings`: form is pre-filled with mock name/email/phone; tabs (Profile / Department / Change Password) all render
5. Click the camera icon on the avatar:  file picker opens; selecting an image replaces the initials live
6. `npm run build`: It was compiled successfully; `/hospital/nurse/messages` and `/hospital/nurse/settings` listed as static routes

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
- Both pages use mock data only.

## Notes / Future considerations
- Notification preferences were not included as they are not part of the current Figma designs, but could be considered for a future iteration of the Nurse Settings page