### PR TITLE
feat: Nurse Portal Schedule & Nursing Notes

### DIFF
--- a/src/app/hospital/nurse/layout.tsx
+++ b/src/app/hospital/nurse/layout.tsx
@@ -30,7 +30,7 @@ export default function HospitalNurseLayout({ children }: { children: React.Reac
                     hospitalName={MOCK_NURSE.hospitalName}
                     onMenuClick={() => setSidebarOpen(true)}
                 />
-                <main className="flex-1 overflow-x-hidden">{children}</main>
+                <main className="flex-1 overflow-x-hidden p-4 lg:p-6">{children}</main>
             </div>
         </div>
     );

--- a/src/app/hospital/nurse/notes/page.tsx
+++ b/src/app/hospital/nurse/notes/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
     Search,
     FileText,
@@ -12,30 +12,104 @@ import {
     RotateCcw,
     ChevronDown,
 } from 'lucide-react';
+import { MOCK_PATIENTS } from '@/mock/hospital/consultations';
+import { MOCK_NURSE } from '@/mock/hospital/user';
+import type { NursingNote } from '@/types/hospital';
+
+const NURSE_NAME = `${MOCK_NURSE.firstName} ${MOCK_NURSE.lastName}`;
+const MOCK_TODAY = '2026-06-09';
+
+const INITIAL_NOTES: NursingNote[] = [
+    {
+        id: 'note-001',
+        patientName: MOCK_PATIENTS[3].name,
+        nurseName: NURSE_NAME,
+        date: MOCK_TODAY,
+        time: '05:15 PM',
+        observationNotes: 'Patient is alert and stable post-load, Vitals stable: BP 115/70, HR 82, Temp 36.7C.',
+        careActivities: '',
+        additionalComments: '',
+    },
+    {
+        id: 'note-002',
+        patientName: MOCK_PATIENTS[4].name,
+        nurseName: NURSE_NAME,
+        date: MOCK_TODAY,
+        time: '04:30 PM',
+        observationNotes: 'Patient complains of mild shoulder pain post-surgery but is stable. Client education reviewed for breath sounds.',
+        careActivities: '',
+        additionalComments: '',
+    },
+    {
+        id: 'note-003',
+        patientName: MOCK_PATIENTS[5].name,
+        nurseName: NURSE_NAME,
+        date: '2026-06-08',
+        time: '10:15 AM',
+        observationNotes: 'Post-operative Day 1 following laparoscopic cholecystectomy. Patient complains of pain around incision site.',
+        careActivities: '',
+        additionalComments: '',
+    },
+];
 
 export default function NursingNotesPage() {
+    const [notes, setNotes] = useState<NursingNote[]>(INITIAL_NOTES);
+    const [search, setSearch] = useState('');
+    const [patientFilter, setPatientFilter] = useState('');
+
     const [selectedPatient, setSelectedPatient] = useState('');
     const [dateTime, setDateTime] = useState('06/09/2026 05:20 PM');
+    const [observationNotes, setObservationNotes] = useState('');
+    const [careActivities, setCareActivities] = useState('');
+    const [additionalComments, setAdditionalComments] = useState('');
+
+    const filteredNotes = useMemo(() => {
+        const q = search.toLowerCase();
+        return notes.filter((note) => {
+            if (patientFilter && note.patientName !== patientFilter) return false;
+            if (q && !note.patientName.toLowerCase().includes(q) && !note.observationNotes.toLowerCase().includes(q)) return false;
+            return true;
+        });
+    }, [notes, search, patientFilter]);
 
     const stats = [
-        { label: 'Notes Created Today', value: 2, icon: <FileText className="w-5 h-5 text-[#38BDF8]" />, bgColor: 'bg-[#F0F9FF]', borderColor: 'border-[#E0F2FE]' },
-        { label: 'Recent Notes', value: 3, icon: <Clock className="w-5 h-5 text-purple-500" />, bgColor: 'bg-purple-50', borderColor: 'border-purple-100' },
-        { label: 'Patients Monitored', value: 3, icon: <Users className="w-5 h-5 text-green-500" />, bgColor: 'bg-green-50', borderColor: 'border-green-100' },
+        { label: 'Notes Created Today', value: notes.filter((n) => n.date === MOCK_TODAY).length, icon: <FileText className="w-5 h-5 text-[#38BDF8]" />, bgColor: 'bg-[#F0F9FF]', borderColor: 'border-[#E0F2FE]' },
+        { label: 'Recent Notes', value: notes.length, icon: <Clock className="w-5 h-5 text-purple-500" />, bgColor: 'bg-purple-50', borderColor: 'border-purple-100' },
+        { label: 'Patients Monitored', value: new Set(notes.map((n) => n.patientName)).size, icon: <Users className="w-5 h-5 text-green-500" />, bgColor: 'bg-green-50', borderColor: 'border-green-100' },
         { label: 'Pending Documentation', value: 2, icon: <AlertCircle className="w-5 h-5 text-red-500" />, bgColor: 'bg-red-50', borderColor: 'border-red-100' },
     ];
 
-    const recentNotes = [
-        { patient: 'Ravine Mugisha', nurse: 'Sarah Nkurunziza', time: '05:15 PM', date: '2026-06-09', snippet: 'Patient is alert and stable post-load, Vitals stable: BP 115/70, HR 82, Temp 36.7C.' },
-        { patient: 'Jean Paul Munginana', nurse: 'Sarah Nkurunziza', time: '04:30 PM', date: '2026-06-09', snippet: "Patient complains of mild shoulder pain post-surgery but is stable. Client education reviewed for breath sounds." },
-        { patient: 'Angelique Umutoni', nurse: 'Sarah Nkurunziza', time: '10:15 AM', date: '2026-06-08', snippet: 'Post-operative Day 1 following laparoscopic cholecystectomy. Patient complains of pain around...' },
-    ];
+    const resetForm = () => {
+        setSelectedPatient('');
+        setDateTime('06/09/2026 05:20 PM');
+        setObservationNotes('');
+        setCareActivities('');
+        setAdditionalComments('');
+    };
+
+    const submitDocumentation = () => {
+        if (!selectedPatient || !observationNotes) return;
+        const [datePart, ...timeParts] = dateTime.split(' ');
+        const newNote: NursingNote = {
+            id: `note-${Date.now()}`,
+            patientName: selectedPatient,
+            nurseName: NURSE_NAME,
+            date: datePart === '06/09/2026' ? MOCK_TODAY : datePart,
+            time: timeParts.join(' ') || dateTime,
+            observationNotes,
+            careActivities,
+            additionalComments,
+        };
+        setNotes((prev) => [newNote, ...prev]);
+        resetForm();
+    };
 
     return (
         <div className="p-6 lg:p-8 space-y-8 bg-[#F8FAFC]">
             {/* Header */}
-            <div className="bg-white rounded-3xl p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
+            <div className="bg-white rounded-3xl p-6 sm:p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
                 <div className="relative z-10">
-                    <h1 className="text-3xl font-bold text-[#1E3A5F]">Nursing Notes & Documentation</h1>
+                    <h1 className="text-2xl sm:text-3xl font-bold text-[#1E3A5F]">Nursing Notes & Documentation</h1>
                     <p className="text-[#64748B] mt-2 max-w-2xl font-medium">
                         Document patient observations, care activities, and treatment outcomes during your shift.
                     </p>
@@ -44,15 +118,15 @@ export default function NursingNotesPage() {
             </div>
 
             {/* Stats */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
                 {stats.map((stat, idx) => (
-                    <div key={idx} className={`p-5 rounded-3xl bg-white border ${stat.borderColor} shadow-sm flex items-center gap-4`}>
-                        <div className={`w-12 h-12 rounded-2xl ${stat.bgColor} flex items-center justify-center`}>
+                    <div key={idx} className={`min-w-0 p-5 rounded-3xl bg-white border ${stat.borderColor} shadow-sm flex items-center gap-4`}>
+                        <div className={`w-12 h-12 shrink-0 rounded-2xl ${stat.bgColor} flex items-center justify-center`}>
                             {stat.icon}
                         </div>
-                        <div>
+                        <div className="min-w-0">
                             <p className="text-2xl font-black text-[#1E3A5F]">{stat.value}</p>
-                            <p className="text-[10px] font-bold text-[#64748B] uppercase tracking-wide">{stat.label}</p>
+                            <p className="text-[10px] font-bold text-[#64748B] uppercase tracking-wide break-words">{stat.label}</p>
                         </div>
                     </div>
                 ))}
@@ -65,6 +139,8 @@ export default function NursingNotesPage() {
                         <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-[#94A3B8] w-4 h-4" />
                         <input
                             type="text"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
                             placeholder="Search notes by patient or content..."
                             className="w-full pl-12 pr-4 py-3 bg-white border border-[#E2E8F0] rounded-2xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] shadow-sm transition-all"
                         />
@@ -72,8 +148,15 @@ export default function NursingNotesPage() {
 
                     <div className="flex gap-4">
                         <div className="relative flex-1">
-                            <select className="w-full pl-4 pr-10 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-xs font-bold text-[#1E3A5F] appearance-none cursor-pointer">
-                                <option>All Patients</option>
+                            <select
+                                value={patientFilter}
+                                onChange={(e) => setPatientFilter(e.target.value)}
+                                className="w-full pl-4 pr-10 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-xs font-bold text-[#1E3A5F] appearance-none cursor-pointer"
+                            >
+                                <option value="">All Patients</option>
+                                {MOCK_PATIENTS.map((p) => (
+                                    <option key={p.id} value={p.name}>{p.name}</option>
+                                ))}
                             </select>
                             <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 text-[#94A3B8] w-4 h-4 pointer-events-none" />
                         </div>
@@ -81,22 +164,28 @@ export default function NursingNotesPage() {
                             <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 text-[#94A3B8] w-3.5 h-3.5" />
                             <input
                                 type="text"
-                                value="06/09/2028"
+                                readOnly
+                                value="06/09/2026"
                                 className="w-full pl-8 pr-4 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-[10px] font-bold text-[#1E3A5F]"
                             />
                         </div>
                     </div>
 
                     <div className="space-y-4">
-                        {recentNotes.map((note, idx) => (
-                            <div key={idx} className="p-4 bg-white border border-[#E2E8F0] rounded-2xl shadow-sm hover:shadow-md transition-all cursor-pointer group">
-                                <div className="flex justify-between items-start mb-2">
-                                    <h4 className="text-sm font-black text-[#1E3A5F]">{note.patient}</h4>
-                                    <span className="text-[10px] font-bold text-[#94A3B8]">{note.time}</span>
+                        {filteredNotes.length === 0 && (
+                            <p className="py-8 text-center text-sm font-semibold text-[#94A3B8]">
+                                No notes yet.
+                            </p>
+                        )}
+                        {filteredNotes.map((note) => (
+                            <div key={note.id} className="p-4 bg-white border border-[#E2E8F0] rounded-2xl shadow-sm hover:shadow-md transition-all cursor-pointer group">
+                                <div className="flex justify-between items-start gap-2 mb-2">
+                                    <h4 className="text-sm font-black text-[#1E3A5F]">{note.patientName}</h4>
+                                    <span className="shrink-0 text-[10px] font-bold text-[#94A3B8]">{note.time}</span>
                                 </div>
-                                <p className="text-[10px] text-[#64748B] mb-2">By {note.nurse} • {note.date}</p>
+                                <p className="text-[10px] text-[#64748B] mb-2">By {note.nurseName} • {note.date}</p>
                                 <p className="text-xs text-[#475569] leading-relaxed line-clamp-3 group-hover:text-[#1E3A5F]">
-                                    {note.snippet}
+                                    {note.observationNotes}
                                 </p>
                             </div>
                         ))}
@@ -105,7 +194,7 @@ export default function NursingNotesPage() {
 
                 {/* Right Column - Form */}
                 <div className="lg:col-span-8">
-                    <div className="bg-white rounded-3xl border border-[#E2E8F0] shadow-sm p-8 space-y-8">
+                    <div className="bg-white rounded-3xl border border-[#E2E8F0] shadow-sm p-6 sm:p-8 space-y-8">
                         <h3 className="text-xl font-bold text-[#1E3A5F]">Create New Nursing Note</h3>
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -118,9 +207,9 @@ export default function NursingNotesPage() {
                                         className="w-full pl-4 pr-10 py-3 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] appearance-none cursor-pointer"
                                     >
                                         <option value="">Select a patient...</option>
-                                        <option>Ravine Mugisha</option>
-                                        <option>Jean Paul Munginana</option>
-                                        <option>Angelique Umutoni</option>
+                                        {MOCK_PATIENTS.map((p) => (
+                                            <option key={p.id} value={p.name}>{p.name}</option>
+                                        ))}
                                     </select>
                                     <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 text-[#94A3B8] w-5 h-5 pointer-events-none" />
                                 </div>
@@ -142,38 +231,51 @@ export default function NursingNotesPage() {
                         <div className="space-y-2">
                             <label className="text-xs font-bold text-[#1E3A5F] uppercase tracking-wide ml-1">Observation Notes *</label>
                             <textarea
+                                value={observationNotes}
+                                onChange={(e) => setObservationNotes(e.target.value)}
                                 placeholder="Enter objective assessments, patient symptoms, vitals, behavior notes..."
                                 rows={4}
                                 className="w-full p-4 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] resize-none"
-                            ></textarea>
+                            />
                         </div>
 
                         <div className="space-y-2">
                             <label className="text-xs font-bold text-[#1E3A5F] uppercase tracking-wide ml-1">Care Activities & Treatments</label>
                             <textarea
+                                value={careActivities}
+                                onChange={(e) => setCareActivities(e.target.value)}
                                 placeholder="Enter care interventions, treatments performed, dressings / site checks..."
                                 rows={3}
                                 className="w-full p-4 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] resize-none"
-                            ></textarea>
+                            />
                         </div>
 
                         <div className="space-y-2">
                             <label className="text-xs font-bold text-[#1E3A5F] uppercase tracking-wide ml-1">Additional Comments / Plans</label>
                             <textarea
+                                value={additionalComments}
+                                onChange={(e) => setAdditionalComments(e.target.value)}
                                 placeholder="Next steps, flags for upcoming shift, medication response..."
                                 rows={2}
                                 className="w-full p-4 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] resize-none"
-                            ></textarea>
+                            />
                         </div>
 
-                        <div className="flex justify-end gap-4 pt-4 border-t border-[#F1F5F9]">
-                            <button className="px-8 py-3 bg-white border border-[#E2E8F0] text-[#64748B] text-sm font-bold rounded-xl hover:bg-gray-50 transition-all flex items-center gap-2">
+                        <div className="flex flex-wrap justify-end gap-4 pt-4 border-t border-[#F1F5F9]">
+                            <button
+                                onClick={resetForm}
+                                className="px-8 py-3 bg-white border border-[#E2E8F0] text-[#64748B] text-sm font-bold rounded-xl hover:bg-gray-50 transition-all flex items-center gap-2"
+                            >
                                 <RotateCcw className="w-4 h-4" />
                                 Reset Form
                             </button>
-                            <button className="px-8 py-3 bg-[#38BDF8] text-white text-sm font-bold rounded-xl hover:bg-[#0EA5E9] transition-all shadow-md flex items-center gap-2">
+                            <button
+                                onClick={submitDocumentation}
+                                disabled={!selectedPatient || !observationNotes}
+                                className="px-8 py-3 bg-[#38BDF8] text-white text-sm font-bold rounded-xl hover:bg-[#0EA5E9] transition-all shadow-md flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
                                 <Save className="w-4 h-4" />
-                                Save Documentation
+                                Submit Documentation
                             </button>
                         </div>
                     </div>

--- a/src/app/hospital/nurse/schedule/page.tsx
+++ b/src/app/hospital/nurse/schedule/page.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircleIcon,
   CalendarDaysIcon,
   ChevronDownIcon,
+  CalendarIcon,
 } from '@heroicons/react/24/outline';
 import { nurseShiftStats, nurseShiftSchedule } from '@/mock/hospital/nurse';
 
@@ -47,13 +48,13 @@ export default function NurseSchedulePage() {
       </div>
 
       {/* Stat cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4">
         {nurseShiftStats.map((stat) => {
           const Icon = STAT_ICONS[stat.key] ?? ClockIcon;
           return (
             <div
               key={stat.key}
-              className="flex items-center gap-4 rounded-xl bg-white px-5 py-4 shadow-sm border border-gray-100"
+              className="flex min-w-0 items-center gap-4 rounded-xl bg-white px-5 py-4 shadow-sm border border-gray-100"
               style={{ borderLeft: `4px solid ${stat.color}` }}
             >
               <div
@@ -63,8 +64,8 @@ export default function NurseSchedulePage() {
                 <Icon className="h-6 w-6" style={{ color: stat.color }} />
               </div>
               <div className="min-w-0">
-                <p className="text-lg font-bold text-slate-900 whitespace-nowrap">{stat.title}</p>
-                <p className="text-xs font-medium text-slate-500 whitespace-nowrap">{stat.subtitle}</p>
+                <p className="text-lg font-bold text-slate-900 break-words">{stat.title}</p>
+                <p className="text-xs font-medium text-slate-500 break-words">{stat.subtitle}</p>
               </div>
             </div>
           );
@@ -90,15 +91,15 @@ export default function NurseSchedulePage() {
           ))}
         </div>
 
-        <div className="relative">
-          <select className="appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
+        <div className="relative min-w-[150px]">
+          <select className="w-full appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
             <option>{t('hospital.allDepartments')}</option>
           </select>
           <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
         </div>
 
-        <div className="relative">
-          <select className="appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
+        <div className="relative min-w-[140px]">
+          <select className="w-full appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
             <option>{t('hospital.allShiftTypes')}</option>
           </select>
           <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
@@ -107,13 +108,21 @@ export default function NurseSchedulePage() {
         <input
           type="date"
           defaultValue="2026-06-09"
-          className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200"
+          className="min-w-[140px] rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200"
         />
       </div>
 
       {/* Timeline */}
       <div className="space-y-3 rounded-2xl bg-white p-4 sm:p-6 shadow-sm border border-gray-100">
-        {nurseShiftSchedule.map((item) => {
+        {view !== 'daily' && (
+          <div className="flex flex-col items-center gap-2 py-12 text-center">
+            <CalendarIcon className="h-8 w-8 text-slate-300" />
+            <p className="text-sm font-semibold text-slate-500">
+              {t(`hospital.${view}ViewComingSoon`)}
+            </p>
+          </div>
+        )}
+        {view === 'daily' && nurseShiftSchedule.map((item) => {
           const statusColor = STATUS_COLOR[item.status];
           const statusLabel =
             item.status === 'COMPLETED'

--- a/src/app/hospital/nurse/schedule/page.tsx
+++ b/src/app/hospital/nurse/schedule/page.tsx
@@ -8,9 +8,14 @@ import {
   CheckCircleIcon,
   CalendarDaysIcon,
   ChevronDownIcon,
-  CalendarIcon,
 } from '@heroicons/react/24/outline';
-import { nurseShiftStats, nurseShiftSchedule } from '@/mock/hospital/nurse';
+import {
+  nurseShiftStats,
+  nurseShiftSchedule,
+  nurseShiftScheduleWeekly,
+  nurseShiftScheduleMonthly,
+} from '@/mock/hospital/nurse';
+import type { NurseShift } from '@/types/hospital';
 
 const NAVY = '#1E3A5F';
 const SKY = '#0EA5E9';
@@ -31,9 +36,16 @@ const STATUS_COLOR: Record<string, string> = {
 type ViewMode = 'daily' | 'weekly' | 'monthly';
 const VIEW_MODES: ViewMode[] = ['daily', 'weekly', 'monthly'];
 
+const SCHEDULE_BY_VIEW: Record<ViewMode, NurseShift[]> = {
+  daily: nurseShiftSchedule,
+  weekly: nurseShiftScheduleWeekly,
+  monthly: nurseShiftScheduleMonthly,
+};
+
 export default function NurseSchedulePage() {
   const { t } = useTranslation();
   const [view, setView] = useState<ViewMode>('daily');
+  const visibleSchedule = SCHEDULE_BY_VIEW[view];
 
   return (
     <div className="space-y-6">
@@ -114,15 +126,12 @@ export default function NurseSchedulePage() {
 
       {/* Timeline */}
       <div className="space-y-3 rounded-2xl bg-white p-4 sm:p-6 shadow-sm border border-gray-100">
-        {view !== 'daily' && (
-          <div className="flex flex-col items-center gap-2 py-12 text-center">
-            <CalendarIcon className="h-8 w-8 text-slate-300" />
-            <p className="text-sm font-semibold text-slate-500">
-              {t(`hospital.${view}ViewComingSoon`)}
-            </p>
-          </div>
+        {visibleSchedule.length === 0 && (
+          <p className="py-12 text-center text-sm font-semibold text-slate-400">
+            {t('hospital.noShiftsScheduled')}
+          </p>
         )}
-        {view === 'daily' && nurseShiftSchedule.map((item) => {
+        {visibleSchedule.map((item) => {
           const statusColor = STATUS_COLOR[item.status];
           const statusLabel =
             item.status === 'COMPLETED'
@@ -133,7 +142,7 @@ export default function NurseSchedulePage() {
 
           return (
             <div key={item.id} className="flex items-center gap-3 sm:gap-5">
-              <span className="hidden w-20 shrink-0 text-right text-xs font-bold text-slate-600 sm:block">
+              <span className="hidden w-24 shrink-0 text-right text-xs font-bold text-slate-600 sm:block">
                 {item.time}
               </span>
               <span className="h-12 w-1 shrink-0 rounded" style={{ background: SKY }} />

--- a/src/app/hospital/nurse/schedule/page.tsx
+++ b/src/app/hospital/nurse/schedule/page.tsx
@@ -1,3 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ClockIcon,
+  FolderIcon,
+  CheckCircleIcon,
+  CalendarDaysIcon,
+  ChevronDownIcon,
+} from '@heroicons/react/24/outline';
+import { nurseShiftStats, nurseShiftSchedule } from '@/mock/hospital/nurse';
+
+const NAVY = '#1E3A5F';
+const SKY = '#0EA5E9';
+
+const STAT_ICONS: Record<string, typeof ClockIcon> = {
+  dayShift: ClockIcon,
+  generalMed: FolderIcon,
+  duties: CheckCircleIcon,
+  shifts: CalendarDaysIcon,
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  COMPLETED: '#94A3B8',
+  ACTIVE: SKY,
+  UPCOMING: '#38BDF8',
+};
+
+type ViewMode = 'daily' | 'weekly' | 'monthly';
+const VIEW_MODES: ViewMode[] = ['daily', 'weekly', 'monthly'];
+
 export default function NurseSchedulePage() {
-  return <div />;
+  const { t } = useTranslation();
+  const [view, setView] = useState<ViewMode>('daily');
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="rounded-2xl px-4 py-5 sm:p-8" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-2xl sm:text-3xl font-bold" style={{ color: NAVY }}>
+          {t('hospital.nurseScheduleTitle')}
+        </h1>
+        <p className="mt-1 text-sm" style={{ color: '#0284C7' }}>
+          {t('hospital.nurseScheduleSubtitle')}
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {nurseShiftStats.map((stat) => {
+          const Icon = STAT_ICONS[stat.key] ?? ClockIcon;
+          return (
+            <div
+              key={stat.key}
+              className="flex items-center gap-4 rounded-xl bg-white px-5 py-4 shadow-sm border border-gray-100"
+              style={{ borderLeft: `4px solid ${stat.color}` }}
+            >
+              <div
+                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full"
+                style={{ background: `${stat.color}1A` }}
+              >
+                <Icon className="h-6 w-6" style={{ color: stat.color }} />
+              </div>
+              <div className="min-w-0">
+                <p className="text-lg font-bold text-slate-900 whitespace-nowrap">{stat.title}</p>
+                <p className="text-xs font-medium text-slate-500 whitespace-nowrap">{stat.subtitle}</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-2 sm:gap-3 rounded-2xl bg-white p-3 sm:p-4 shadow-sm border border-gray-100">
+        <div className="flex rounded-lg bg-slate-100 p-1">
+          {VIEW_MODES.map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setView(mode)}
+              className="rounded-md px-3 py-1.5 text-xs font-semibold transition-colors whitespace-nowrap"
+              style={
+                view === mode
+                  ? { background: '#FFFFFF', color: SKY, boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)' }
+                  : { color: '#64748B' }
+              }
+            >
+              {t(`hospital.${mode}View`)}
+            </button>
+          ))}
+        </div>
+
+        <div className="relative">
+          <select className="appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
+            <option>{t('hospital.allDepartments')}</option>
+          </select>
+          <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        </div>
+
+        <div className="relative">
+          <select className="appearance-none rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-8 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200">
+            <option>{t('hospital.allShiftTypes')}</option>
+          </select>
+          <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        </div>
+
+        <input
+          type="date"
+          defaultValue="2026-06-09"
+          className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-200"
+        />
+      </div>
+
+      {/* Timeline */}
+      <div className="space-y-3 rounded-2xl bg-white p-4 sm:p-6 shadow-sm border border-gray-100">
+        {nurseShiftSchedule.map((item) => {
+          const statusColor = STATUS_COLOR[item.status];
+          const statusLabel =
+            item.status === 'COMPLETED'
+              ? t('hospital.completed')
+              : item.status === 'ACTIVE'
+                ? t('hospital.active')
+                : t('hospital.upcoming');
+
+          return (
+            <div key={item.id} className="flex items-center gap-3 sm:gap-5">
+              <span className="hidden w-20 shrink-0 text-right text-xs font-bold text-slate-600 sm:block">
+                {item.time}
+              </span>
+              <span className="h-12 w-1 shrink-0 rounded" style={{ background: SKY }} />
+              <div className="flex min-w-0 flex-1 items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 sm:px-5">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold text-slate-600 sm:hidden">{item.time}</p>
+                  <p className="text-sm font-bold text-slate-900">{item.title}</p>
+                  <p className="text-xs text-slate-500">{item.description}</p>
+                </div>
+                <span
+                  className="shrink-0 text-xs font-bold uppercase tracking-wide"
+                  style={{ color: statusColor }}
+                >
+                  {statusLabel}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1654,6 +1654,16 @@ export const en = {
     viewAllPatients: 'View All Patients',
     todaySchedule: 'Today\'s Schedule',
     viewFullSchedule: 'View Full Schedule',
+
+    //nurse - Schedule & Shifts page
+    nurseScheduleTitle: 'Nurse Schedule & Shifts',
+    nurseScheduleSubtitle: 'Organize, view, and coordinate your ward shift timings and clinical duties.',
+    dailyView: 'Daily View',
+    weeklyView: 'Weekly View',
+    monthlyView: 'Monthly View',
+    allDepartments: 'All Departments',
+    allShiftTypes: 'All Shift Types',
+    upcoming: 'Upcoming',
   },
   bulkUploadPage: {
     addManually: 'Add Manually',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1664,8 +1664,7 @@ export const en = {
     allDepartments: 'All Departments',
     allShiftTypes: 'All Shift Types',
     upcoming: 'Upcoming',
-    weeklyViewComingSoon: 'Weekly view is coming soon.',
-    monthlyViewComingSoon: 'Monthly view is coming soon.',
+    noShiftsScheduled: 'No shifts scheduled.',
   },
   bulkUploadPage: {
     addManually: 'Add Manually',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1664,6 +1664,8 @@ export const en = {
     allDepartments: 'All Departments',
     allShiftTypes: 'All Shift Types',
     upcoming: 'Upcoming',
+    weeklyViewComingSoon: 'Weekly view is coming soon.',
+    monthlyViewComingSoon: 'Monthly view is coming soon.',
   },
   bulkUploadPage: {
     addManually: 'Add Manually',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1626,6 +1626,8 @@ export const fr = {
     allDepartments: 'Tous les Départements',
     allShiftTypes: 'Tous les Types de Garde',
     upcoming: 'À venir',
+    weeklyViewComingSoon: 'La vue hebdomadaire arrive bientôt.',
+    monthlyViewComingSoon: 'La vue mensuelle arrive bientôt.',
   },
   bulkUploadPage: {
     addManually: 'Saisie manuelle',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1616,6 +1616,16 @@ export const fr = {
     hospitalProfile: 'Profil de l\'hôpital',
     adminProfile: 'Profil administrateur',
     logout: 'Déconnexion',
+
+    // [FR TODO] best-effort, not verified by a native speaker - nurse Schedule & Shifts page
+    nurseScheduleTitle: 'Horaire et Gardes Infirmières',
+    nurseScheduleSubtitle: 'Organisez, consultez et coordonnez les horaires de garde et les tâches cliniques de votre service.',
+    dailyView: 'Vue Journalière',
+    weeklyView: 'Vue Hebdomadaire',
+    monthlyView: 'Vue Mensuelle',
+    allDepartments: 'Tous les Départements',
+    allShiftTypes: 'Tous les Types de Garde',
+    upcoming: 'À venir',
   },
   bulkUploadPage: {
     addManually: 'Saisie manuelle',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1626,8 +1626,7 @@ export const fr = {
     allDepartments: 'Tous les Départements',
     allShiftTypes: 'Tous les Types de Garde',
     upcoming: 'À venir',
-    weeklyViewComingSoon: 'La vue hebdomadaire arrive bientôt.',
-    monthlyViewComingSoon: 'La vue mensuelle arrive bientôt.',
+    noShiftsScheduled: 'Aucune garde programmée.',
   },
   bulkUploadPage: {
     addManually: 'Saisie manuelle',

--- a/src/lib/i18n/rw.ts
+++ b/src/lib/i18n/rw.ts
@@ -1627,6 +1627,8 @@ export const rw = {
     allDepartments: 'Amashami Yose',
     allShiftTypes: 'Uburyo Bwose bw\'Amasaha',
     upcoming: 'Bizaza',
+    weeklyViewComingSoon: 'Kureba ku cyumweru biraza vuba.',
+    monthlyViewComingSoon: 'Kureba ku kwezi biraza vuba.',
   },
   bulkUploadPage: {
     addManually: 'Injiza Buri Kimwe',

--- a/src/lib/i18n/rw.ts
+++ b/src/lib/i18n/rw.ts
@@ -1617,6 +1617,16 @@ export const rw = {
     hospitalProfile: 'Amakuru y\'Ibitaro',
     adminProfile: 'Amakuru y\'Ubutegetsi',
     logout: 'Sohoka',
+
+    // [REVIEW RW] proposed translation, needs native-speaker confirmation - nurse Schedule & Shifts page
+    nurseScheduleTitle: 'Gahunda n\'Amasaha y\'Ubuforomo',
+    nurseScheduleSubtitle: 'Tegura, reba, kandi uhuze amasaha y\'umurimo n\'imirimo y\'ubuvuzi muri serivisi yawe.',
+    dailyView: 'Ku Munsi',
+    weeklyView: 'Ku Cyumweru',
+    monthlyView: 'Ku Kwezi',
+    allDepartments: 'Amashami Yose',
+    allShiftTypes: 'Uburyo Bwose bw\'Amasaha',
+    upcoming: 'Bizaza',
   },
   bulkUploadPage: {
     addManually: 'Injiza Buri Kimwe',

--- a/src/lib/i18n/rw.ts
+++ b/src/lib/i18n/rw.ts
@@ -1627,8 +1627,7 @@ export const rw = {
     allDepartments: 'Amashami Yose',
     allShiftTypes: 'Uburyo Bwose bw\'Amasaha',
     upcoming: 'Bizaza',
-    weeklyViewComingSoon: 'Kureba ku cyumweru biraza vuba.',
-    monthlyViewComingSoon: 'Kureba ku kwezi biraza vuba.',
+    noShiftsScheduled: 'Nta gahunda y\'amasaha ihari.',
   },
   bulkUploadPage: {
     addManually: 'Injiza Buri Kimwe',

--- a/src/mock/hospital/nurse.ts
+++ b/src/mock/hospital/nurse.ts
@@ -1,4 +1,4 @@
-import type { NurseDashboardStats, NursePatientOverview, NurseScheduleItem } from '@/types/hospital';
+import type { NurseDashboardStats, NursePatientOverview, NurseScheduleItem, NurseShiftStat, NurseShiftScheduleItem } from '@/types/hospital';
 
 export const nurseDashboardStats: NurseDashboardStats = {
   totalPatients: 6,
@@ -100,4 +100,24 @@ export const nurseSchedule: NurseScheduleItem[] = [
     location: '30 min',
     status: 'Upcoming',
   },
+];
+
+// Nurse Schedule & Shifts page
+
+export const nurseShiftStats: NurseShiftStat[] = [
+  { key: 'dayShift', title: 'Day Shift', subtitle: '07:00 AM - 03:00 PM', color: '#0EA5E9' },
+  { key: 'generalMed', title: 'General Med', subtitle: 'Next: ICU (June 10)', color: '#8B5CF6' },
+  { key: 'duties', title: '5 Duties', subtitle: 'Tasks Today', color: '#10B981' },
+  { key: 'shifts', title: '4 Shifts', subtitle: 'Weekly Assignments', color: '#F59E0B' },
+];
+
+export const nurseShiftSchedule: NurseShiftScheduleItem[] = [
+  { id: 'shift-1', time: '07:00 AM', title: 'Shift Handover & Morning ward briefing', description: 'Ward A & B staffing allocations, patient safety review.', status: 'COMPLETED' },
+  { id: 'shift-2', time: '08:00 AM', title: 'Patient Rounds & Vitals Inspections', description: 'Record routine BP, HR, SpO2, and temperature levels.', status: 'COMPLETED' },
+  { id: 'shift-3', time: '09:00 AM', title: 'Morning Medication Administration Round', description: 'Administer prescribed oral, SubQ, and IV treatments.', status: 'COMPLETED' },
+  { id: 'shift-4', time: '11:00 AM', title: 'Doctor Rounds Accompaniment', description: 'Join Dr. Samuel Nkurunziza for detailed clinical review.', status: 'COMPLETED' },
+  { id: 'shift-5', time: '12:00 PM', title: 'Lunch Handover & Mid-Shift Check', description: 'Mid-day briefing and vital assessments review.', status: 'COMPLETED' },
+  { id: 'shift-6', time: '01:00 PM', title: 'Afternoon Assessment & Documentation', description: 'Log clinical assessments and update nursing notes.', status: 'ACTIVE' },
+  { id: 'shift-7', time: '02:00 PM', title: 'Afternoon Medication Administration Round', description: 'Administer scheduled afternoon medication doses.', status: 'UPCOMING' },
+  { id: 'shift-8', time: '03:00 PM', title: 'Shift Handover to Evening Nurse Team', description: 'Perform formal bedside handoff and patient review.', status: 'UPCOMING' },
 ];

--- a/src/mock/hospital/nurse.ts
+++ b/src/mock/hospital/nurse.ts
@@ -1,4 +1,4 @@
-import type { NurseDashboardStats, NursePatientOverview, NurseScheduleItem, NurseShiftStat, NurseShiftScheduleItem } from '@/types/hospital';
+import type { NurseDashboardStats, NursePatientOverview, NurseScheduleItem, NurseShiftStat, NurseShift } from '@/types/hospital';
 
 export const nurseDashboardStats: NurseDashboardStats = {
   totalPatients: 6,
@@ -111,7 +111,7 @@ export const nurseShiftStats: NurseShiftStat[] = [
   { key: 'shifts', title: '4 Shifts', subtitle: 'Weekly Assignments', color: '#F59E0B' },
 ];
 
-export const nurseShiftSchedule: NurseShiftScheduleItem[] = [
+export const nurseShiftSchedule: NurseShift[] = [
   { id: 'shift-1', time: '07:00 AM', title: 'Shift Handover & Morning ward briefing', description: 'Ward A & B staffing allocations, patient safety review.', status: 'COMPLETED' },
   { id: 'shift-2', time: '08:00 AM', title: 'Patient Rounds & Vitals Inspections', description: 'Record routine BP, HR, SpO2, and temperature levels.', status: 'COMPLETED' },
   { id: 'shift-3', time: '09:00 AM', title: 'Morning Medication Administration Round', description: 'Administer prescribed oral, SubQ, and IV treatments.', status: 'COMPLETED' },
@@ -120,4 +120,21 @@ export const nurseShiftSchedule: NurseShiftScheduleItem[] = [
   { id: 'shift-6', time: '01:00 PM', title: 'Afternoon Assessment & Documentation', description: 'Log clinical assessments and update nursing notes.', status: 'ACTIVE' },
   { id: 'shift-7', time: '02:00 PM', title: 'Afternoon Medication Administration Round', description: 'Administer scheduled afternoon medication doses.', status: 'UPCOMING' },
   { id: 'shift-8', time: '03:00 PM', title: 'Shift Handover to Evening Nurse Team', description: 'Perform formal bedside handoff and patient review.', status: 'UPCOMING' },
+];
+
+export const nurseShiftScheduleWeekly: NurseShift[] = [
+  { id: 'week-mon', time: 'Monday', title: 'Day Shift — General Medicine', description: '07:00 AM - 03:00 PM, Ward A & B.', status: 'COMPLETED' },
+  { id: 'week-tue', time: 'Tuesday', title: 'Day Shift — ICU', description: '07:00 AM - 03:00 PM, ICU coverage.', status: 'COMPLETED' },
+  { id: 'week-wed', time: 'Wednesday', title: 'Day Shift — General Medicine', description: '07:00 AM - 03:00 PM, Ward A & B.', status: 'COMPLETED' },
+  { id: 'week-thu', time: 'Thursday', title: 'Day Shift — General Medicine', description: '07:00 AM - 03:00 PM, Ward A & B.', status: 'ACTIVE' },
+  { id: 'week-fri', time: 'Friday', title: 'Day Shift — Surgery Recovery', description: '07:00 AM - 03:00 PM, post-op monitoring.', status: 'UPCOMING' },
+  { id: 'week-sat', time: 'Saturday', title: 'Off Duty', description: 'No shift scheduled.', status: 'UPCOMING' },
+  { id: 'week-sun', time: 'Sunday', title: 'Off Duty', description: 'No shift scheduled.', status: 'UPCOMING' },
+];
+
+export const nurseShiftScheduleMonthly: NurseShift[] = [
+  { id: 'month-w1', time: 'Week 1 (Jun 1-7)', title: '5 Day Shifts', description: 'General Medicine & ICU rotation.', status: 'COMPLETED' },
+  { id: 'month-w2', time: 'Week 2 (Jun 8-14)', title: '4 Day Shifts, 1 Night Shift', description: 'ICU coverage, one overnight cover.', status: 'ACTIVE' },
+  { id: 'month-w3', time: 'Week 3 (Jun 15-21)', title: '5 Day Shifts', description: 'General Medicine & Surgery Recovery.', status: 'UPCOMING' },
+  { id: 'month-w4', time: 'Week 4 (Jun 22-28)', title: '3 Day Shifts, 2 Night Shifts', description: 'Mixed rotation, ward coverage.', status: 'UPCOMING' },
 ];

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -400,3 +400,20 @@ export interface NurseScheduleItem {
   location: string;
   status: 'Completed' | 'Upcoming';
 }
+
+// Nurse Schedule & Shifts page
+
+export interface NurseShiftStat {
+  key: string;
+  title: string;
+  subtitle: string;
+  color: string;
+}
+
+export interface NurseShiftScheduleItem {
+  id: string;
+  time: string;
+  title: string;
+  description: string;
+  status: 'COMPLETED' | 'ACTIVE' | 'UPCOMING';
+}

--- a/src/types/hospital.ts
+++ b/src/types/hospital.ts
@@ -410,10 +410,23 @@ export interface NurseShiftStat {
   color: string;
 }
 
-export interface NurseShiftScheduleItem {
+export interface NurseShift {
   id: string;
   time: string;
   title: string;
   description: string;
   status: 'COMPLETED' | 'ACTIVE' | 'UPCOMING';
+}
+
+// Nurse Notes & Documentation page
+
+export interface NursingNote {
+  id: string;
+  patientName: string;
+  nurseName: string;
+  date: string;
+  time: string;
+  observationNotes: string;
+  careActivities: string;
+  additionalComments: string;
 }


### PR DESCRIPTION
## Summary

- Implements the previously-empty `src/app/hospital/nurse/schedule/page.tsx` against the Nurse Portal Figma frame (`node-id=1237-86`, SCHEDULE section `1237:831`): stat cards, Daily/Weekly/Monthly filter bar with department/shift-type dropdowns and a date picker, and a shift timeline with COMPLETED/ACTIVE/UPCOMING status.
- Enhances the existing `src/app/hospital/nurse/notes/page.tsx` (shipped in PR #99) so it's fully functional rather than decorative: reuses `MOCK_PATIENTS`, wires the create-note form to state, and makes Submit/Reset actually work.
- New types `NurseShift`, `NurseShiftStat`, `NursingNote` (additive — existing `NurseScheduleItem` used by the nurse dashboard is untouched).
- Fixes a pre-existing gap: the shared `src/app/hospital/nurse/layout.tsx` `<main>` had no content padding (admin layout already has `p-4 lg:p-6`).

## Color decision

The ticket specified `#2D9B8A` (teal). Pulled the actual Figma file and the stat-card accent color there is `#0EA5E9` (Tailwind sky-500) — same family as the app's existing `#38BDF8`, not teal. Used `#0EA5E9`/`#38BDF8` to match both the Figma and the rest of the app.

## Schedule: Day/Week/Month toggle

Switches between three separate mock arrays (`nurseShiftSchedule`, `nurseShiftScheduleWeekly`, `nurseShiftScheduleMonthly`) rendered through the same row component — no real date logic, as scoped. Verified via Playwright: Daily shows 8 entries, Weekly 7, Monthly 4, and switching back to Daily restores the original list.

## Notes: functional gaps closed

The page already matched the Figma visually (PR #99) — the gaps were behavioral:
- Patient dropdown/filter and seed notes now come from `MOCK_PATIENTS` (`src/mock/hospital/consultations.ts`) instead of three hardcoded names not present anywhere else in the app
- All 3 textareas wired to state (previously uncontrolled — caused a React console warning)
- Submit Documentation prepends a new `NursingNote` to a local `useState` array with no reload; Reset Form clears the inputs; verified via Playwright (count 3 → 4, new note's patient name at index 0)
- "No notes yet" empty state when search/filter returns nothing
- Responsive pass at 1440/1024/768/390px — stat card grid no longer risks clipping at the same `lg` breakpoint the sidebar appears (same root cause as the earlier Schedule fix)

## i18n

Schedule page wired with `react-i18next` (matches the dashboard, the dominant pattern among nurse pages). Notes page intentionally left hardcoded English per discussion with the requester — wiring it would mean FR/RW translations for every label on a text-heavy page, which is real added scope the spec doesn't call for; can be a fast follow-up.

New `hospital.*` i18n keys added to `en.ts`/`fr.ts`/`rw.ts`:
- `en.ts`: real strings
- `fr.ts`: best-effort, **not verified** — flagged `// [FR TODO]` in the file
- `rw.ts`: proposed translation, **needs native-speaker confirmation** — flagged `// [REVIEW RW]` in the file

## Out of scope

- No backend integration — both pages are mock-data only, matching the task spec ("Swagger endpoints: None yet").
- A pre-existing floating Next.js dev-mode indicator was noticed during testing on every page; it's framework chrome (`next dev` only), not present in production, not part of this change.

## Test plan (acceptance criteria)

- [x] `/hospital/nurse/schedule` shows header, 4 stat cards, view toggle + filters, shift list with status badges — matches Figma screenshot
- [x] `/hospital/nurse/notes` shows header, 4 stat cards, notes list (left) + working Create New Nursing Note form (right)
- [x] Filling the form and clicking Submit Documentation adds a new note at the top of the list with no page reload (Playwright-verified)
- [x] Switching Day/Week/Month on the schedule page changes the rendered shift list (Playwright-verified: 8 → 7 → 4 entries)
- [x] `npm run build` — exit 0, no TypeScript errors
- [x] `grep -n "MOCK_PATIENTS" src/app/hospital/nurse/notes/page.tsx` — found, reused not duplicated
- [x] Both pages checked at desktop (1440/1024) and mobile (768/390) widths