### PR TITLE
Design qa pass

### DIFF
--- a/src/app/hospital/admin/appointments/page.tsx
+++ b/src/app/hospital/admin/appointments/page.tsx
@@ -1,9 +1,140 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { MagnifyingGlassIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { MOCK_APPOINTMENTS } from '@/mock/hospital/appointments';
+import type { Appointment } from '@/types/hospital';
+
+const STATUS_STYLE: Record<string, { bg: string; color: string; dot: string; label: string }> = {
+  CONFIRMED:        { bg: '#ECFDF5', color: '#059669', dot: '#10B981', label: 'Confirmed' },
+  PENDING:          { bg: '#FFFBEB', color: '#D97706', dot: '#F59E0B', label: 'Pending' },
+  READY_FOR_DOCTOR: { bg: '#EFF6FF', color: '#2563EB', dot: '#3B82F6', label: 'Ready' },
+  COMPLETED:        { bg: '#ECFDF5', color: '#059669', dot: '#10B981', label: 'Completed' },
+  CANCELLED:        { bg: '#FEF2F2', color: '#DC2626', dot: '#EF4444', label: 'Cancelled' },
+};
+
+function formatDateTime(iso: string) {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}, ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
 export default function HospitalAdminAppointmentsPage() {
+  const [search, setSearch] = useState('');
+  const [doctor, setDoctor] = useState('');
+  const [department, setDepartment] = useState('');
+  const [date, setDate] = useState('');
+
+  const doctors = useMemo(() => [...new Set(MOCK_APPOINTMENTS.map(a => a.doctorName).filter(Boolean))].sort(), []);
+  const departments = useMemo(() => [...new Set(MOCK_APPOINTMENTS.map(a => a.specialization).filter(Boolean))].sort() as string[], []);
+
+  const filtered = MOCK_APPOINTMENTS.filter((a: Appointment) => {
+    const q = search.trim().toLowerCase();
+    if (q && !(a.patientName?.toLowerCase().includes(q) || a.doctorName?.toLowerCase().includes(q))) return false;
+    if (doctor && a.doctorName !== doctor) return false;
+    if (department && a.specialization !== department) return false;
+    if (date && a.date.slice(0, 10) !== date) return false;
+    return true;
+  });
+
+  const reset = () => { setSearch(''); setDoctor(''); setDepartment(''); setDate(''); };
+
   return (
     <div className="space-y-6">
+      {/* Hero */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Appointments</h1>
-        <p className="mt-1 text-sm font-medium" style={{ color: '#2D9B8A' }}>Manage hospital appointments</p>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Appointment Scheduling &amp; Tracking</h1>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Manage and track scheduled patient appointments</p>
+      </div>
+
+      {/* Filter bar */}
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 flex flex-col lg:flex-row lg:items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <MagnifyingGlassIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search patient or doctor name..."
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <select value={doctor} onChange={e => setDoctor(e.target.value)} className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="">All Doctors</option>
+            {doctors.map(d => <option key={d} value={d}>{d}</option>)}
+          </select>
+          <select value={department} onChange={e => setDepartment(e.target.value)} className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="">All Departments</option>
+            {departments.map(d => <option key={d} value={d}>{d}</option>)}
+          </select>
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button onClick={reset} className="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse min-w-[820px]">
+            <thead>
+              <tr className="border-b border-gray-100 text-[11px] font-bold text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-4">Patient Name</th>
+                <th className="px-6 py-4">Assigned Doctor</th>
+                <th className="px-6 py-4">Department</th>
+                <th className="px-6 py-4">Scheduled Date &amp; Time</th>
+                <th className="px-6 py-4">Status</th>
+                <th className="px-6 py-4">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50 text-sm">
+              {filtered.length === 0 ? (
+                <tr><td colSpan={6} className="px-6 py-12 text-center text-gray-400 font-medium">No appointments found.</td></tr>
+              ) : filtered.map((a: Appointment) => {
+                const st = STATUS_STYLE[a.status] ?? { bg: '#F3F4F6', color: '#6B7280', dot: '#9CA3AF', label: a.status };
+                const noActions = a.status === 'COMPLETED' || a.status === 'CANCELLED';
+                return (
+                  <tr key={a.id} className="hover:bg-gray-50/70 transition-colors">
+                    <td className="px-6 py-4 font-bold text-gray-900">{a.patientName}</td>
+                    <td className="px-6 py-4 text-gray-600">{a.doctorName}</td>
+                    <td className="px-6 py-4">
+                      <span className="inline-block px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider" style={{ background: '#EFF6FF', color: '#2563EB' }}>
+                        {a.specialization}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-gray-500">{formatDateTime(a.date)}</td>
+                    <td className="px-6 py-4">
+                      <span className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-[10px] font-bold uppercase tracking-wider" style={{ background: st.bg, color: st.color }}>
+                        <span className="h-1.5 w-1.5 rounded-full" style={{ background: st.dot }} />
+                        {st.label}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      {noActions ? (
+                        <span className="text-xs text-gray-300 font-medium">No actions</span>
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <button aria-label="Approve" className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 text-emerald-600 hover:bg-emerald-50 transition-colors">
+                            <CheckIcon className="w-4 h-4" />
+                          </button>
+                          <button aria-label="Reject" className="w-7 h-7 flex items-center justify-center rounded-lg border border-gray-200 text-red-500 hover:bg-red-50 transition-colors">
+                            <XMarkIcon className="w-4 h-4" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/app/hospital/admin/dashboard/page.tsx
+++ b/src/app/hospital/admin/dashboard/page.tsx
@@ -23,6 +23,8 @@ export default function HospitalAdminDashboardPage() {
       label: t('hospital.appointments'),
       value: 9,
       statusText: '18% vs yesterday',
+      statusColor: 'text-emerald-600',
+      up: true,
       accent: 'border-brand-navy',
       iconBg: 'bg-brand-navy/10',
       iconColor: 'text-brand-navy',
@@ -33,6 +35,8 @@ export default function HospitalAdminDashboardPage() {
       label: t('hospital.activeDoctors'),
       value: 6,
       statusText: t('hospital.onDutyToday'),
+      statusColor: 'text-slate-500',
+      up: false,
       accent: 'border-amber-500',
       iconBg: 'bg-amber-100',
       iconColor: 'text-amber-600',
@@ -43,6 +47,8 @@ export default function HospitalAdminDashboardPage() {
       label: t('hospital.procuredValue'),
       value: '1,850,000 RWF',
       statusText: '12% budget utilization',
+      statusColor: 'text-emerald-600',
+      up: true,
       accent: 'border-emerald-500',
       iconBg: 'bg-emerald-100',
       iconColor: 'text-emerald-600',
@@ -53,6 +59,8 @@ export default function HospitalAdminDashboardPage() {
       label: t('hospital.lowStockExpiry'),
       value: 7,
       statusText: t('hospital.requiresImmediateAttention'),
+      statusColor: 'text-red-500',
+      up: false,
       accent: 'border-red-500',
       iconBg: 'bg-red-100',
       iconColor: 'text-red-600',
@@ -117,7 +125,7 @@ export default function HospitalAdminDashboardPage() {
           <h1 className="text-4xl sm:text-5xl font-black mb-3 text-brand-blue-light">
             {getGreeting()}, {firstName}.
           </h1>
-          <p className="text-lg text-brand-navy-dark">
+          <p className="text-lg" style={{ color: '#0284C7' }}>
             {t('hospital.adminWelcomeMessage')}
           </p>
           <Link
@@ -139,7 +147,7 @@ export default function HospitalAdminDashboardPage() {
           >
             <div className="flex items-center justify-between gap-4">
               <div>
-                <p className={`text-sm font-semibold ${card.labelClass}`}>
+                <p className={`text-xs font-bold uppercase tracking-wider ${card.labelClass}`}>
                   {card.label}
                 </p>
                 <h3 className="mt-2 text-3xl font-bold text-slate-900">
@@ -150,7 +158,9 @@ export default function HospitalAdminDashboardPage() {
                 <card.icon className={`w-6 h-6 ${card.iconColor}`} />
               </div>
             </div>
-            <p className="mt-4 text-sm text-slate-500">{card.statusText}</p>
+            <p className={`mt-4 text-sm font-medium ${card.statusColor}`}>
+              {card.up && <span className="mr-0.5">↑</span>}{card.statusText}
+            </p>
           </div>
         ))}
       </div>

--- a/src/app/hospital/admin/departments/page.tsx
+++ b/src/app/hospital/admin/departments/page.tsx
@@ -1,61 +1,100 @@
 'use client';
 
+import { useState } from 'react';
 import {
-  Heart,
   Stethoscope,
-  SmilePlus,
-  Scissors,
-  Brain,
-  Bone,
-  Fingerprint,
+  Microscope,
+  HeartHandshake,
+  Briefcase,
+  Building2,
   Users,
-  UserCog,
+  Activity,
+  FlaskConical,
+  Clock,
+  HeartPulse,
+  Truck,
+  DollarSign,
   GitFork,
-  MoreVertical,
+  Search,
   type LucideIcon,
 } from 'lucide-react';
-import { MOCK_DEPARTMENTS } from '@/mock/hospital/staff';
 
 const NAVY = '#1E3A5F';
-const TEAL = '#2D9B8A';
 
-const DEPT_META: Record<string, { color: string; icon: LucideIcon }> = {
-  'Cardiology':       { color: '#2563EB', icon: Heart        },
-  'General Medicine': { color: '#0F766E', icon: Stethoscope  },
-  'Paediatrics':      { color: '#BE185D', icon: SmilePlus    },
-  'Surgery':          { color: '#BE123C', icon: Scissors     },
-  'Neurology':        { color: '#6D28D9', icon: Brain        },
-  'Orthopaedics':     { color: '#4338CA', icon: Bone         },
-  'Dermatology':      { color: '#B45309', icon: Fingerprint  },
-};
+interface ServiceRow { icon: LucideIcon; label: string; value: string; }
+interface ServiceGroup { title: string; color: string; icon: LucideIcon; rows: ServiceRow[]; }
 
-const STATUS_STYLE: Record<string, { bg: string; color: string }> = {
-  ACTIVE:   { bg: '#F0FDF4', color: '#15803D' },
-  INACTIVE: { bg: '#FFF7ED', color: '#C2410C' },
-};
+const SERVICE_GROUPS: ServiceGroup[] = [
+  {
+    title: 'Clinical Services', color: '#16A34A', icon: Stethoscope,
+    rows: [
+      { icon: Building2, label: 'Departments', value: '16' },
+      { icon: Users,     label: 'Staff',       value: '250 Doctors' },
+      { icon: Activity,  label: 'Status',      value: 'High Activity' },
+    ],
+  },
+  {
+    title: 'Diagnostic Services', color: '#7C3AED', icon: Microscope,
+    rows: [
+      { icon: Building2,    label: 'Departments',    value: '8' },
+      { icon: FlaskConical, label: 'Tests Today',    value: '130' },
+      { icon: Clock,        label: 'Avg Turnaround', value: '1.4 Hrs' },
+    ],
+  },
+  {
+    title: 'Patient Support Services', color: '#2563EB', icon: HeartHandshake,
+    rows: [
+      { icon: Building2, label: 'Departments',          value: '10' },
+      { icon: HeartPulse, label: 'Active Cases',        value: '67' },
+      { icon: Truck,     label: 'Ambulance Trips Today', value: '12' },
+    ],
+  },
+  {
+    title: 'Administrative & Operations', color: '#EA580C', icon: Briefcase,
+    rows: [
+      { icon: Building2,  label: 'Departments',      value: '12' },
+      { icon: Users,      label: 'Staff',            value: '35 Employees' },
+      { icon: DollarSign, label: "Today's billing",  value: 'Rwf 1,250,000' },
+    ],
+  },
+];
+
+interface Employee { name: string; department: string; phone: string; available: boolean; }
+
+const EMPLOYEES: Employee[] = [
+  { name: 'Ella Mutesi',  department: 'Clinical Services',         phone: '+250784266000', available: true  },
+  { name: 'Kelly Butera', department: 'Patient Support Services',  phone: '+250788013456', available: true  },
+  { name: 'Mary Kagabo',  department: 'Administrative & Operations', phone: '+250783000876', available: false },
+  { name: 'Howard Magaju',department: 'Diagnostic Services',       phone: '+250788456521', available: false },
+];
 
 export default function HospitalAdminDepartmentsPage() {
+  const [search, setSearch] = useState('');
+  const [dept, setDept] = useState('All');
+  const [availability, setAvailability] = useState('All');
+
+  const departments = ['All', ...SERVICE_GROUPS.map(g => g.title)];
+
+  const filtered = EMPLOYEES.filter(e => {
+    if (search.trim() && !e.name.toLowerCase().includes(search.trim().toLowerCase())) return false;
+    if (dept !== 'All' && e.department !== dept) return false;
+    if (availability === 'Available' && !e.available) return false;
+    if (availability === 'Unavailable' && e.available) return false;
+    return true;
+  });
+
   return (
     <div className="space-y-6 w-full max-w-full overflow-x-hidden">
-
-      {/* ── Header ── */}
-      <div
-        className="rounded-2xl px-6 py-7 flex items-start justify-between"
-        style={{ background: '#EBF5FF' }}
-      >
+      {/* Header */}
+      <div className="rounded-2xl px-6 py-7 flex items-start justify-between" style={{ background: '#EBF5FF' }}>
         <div className="space-y-3">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold" style={{ color: NAVY }}>
-              Departments
-            </h1>
-            <p className="mt-1 text-sm font-medium" style={{ color: TEAL }}>
+            <h1 className="text-2xl sm:text-3xl font-bold" style={{ color: NAVY }}>Departments</h1>
+            <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>
               Access and manage doctors, nurses and hospital staff in one place.
             </p>
           </div>
-          <button
-            className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
-            style={{ background: TEAL }}
-          >
+          <button className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity" style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}>
             <Stethoscope size={15} />
             Select Department
           </button>
@@ -65,76 +104,108 @@ export default function HospitalAdminDepartmentsPage() {
         </div>
       </div>
 
-      {/* ── Department cards ── */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {MOCK_DEPARTMENTS.map(dept => {
-          const meta  = DEPT_META[dept.name] ?? { color: TEAL, icon: Stethoscope };
-          const { color, icon: Icon } = meta;
-          const badge = STATUS_STYLE[dept.status] ?? STATUS_STYLE.ACTIVE;
-
-          const rows = [
-            { icon: Users,   label: 'Doctors',    value: String(dept.doctorCount)                         },
-            { icon: Users,   label: 'Nurses',      value: String(dept.nurseCount)                          },
-            { icon: Users,   label: 'Total Staff', value: String(dept.doctorCount + dept.nurseCount)       },
-            { icon: UserCog, label: 'Head',         value: dept.head ?? '—'                                },
-          ];
-
+      {/* Service group cards */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        {SERVICE_GROUPS.map(group => {
+          const Icon = group.icon;
           return (
-            <div
-              key={dept.id}
-              className="bg-white rounded-2xl border shadow-sm p-4 hover:shadow-md transition-shadow cursor-pointer"
-              style={{ borderColor: `${color}30` }}
-            >
-              {/* Icon + name + status */}
-              <div className="flex flex-col items-center gap-2 mb-4">
-                <div
-                  className="w-11 h-11 rounded-2xl flex items-center justify-center"
-                  style={{ background: `${color}15` }}
-                >
-                  <Icon size={20} style={{ color }} />
+            <div key={group.title} className="bg-white rounded-2xl border shadow-sm p-6" style={{ borderColor: `${group.color}25` }}>
+              <div className="flex flex-col items-center gap-2 mb-5">
+                <div className="w-12 h-12 rounded-2xl flex items-center justify-center" style={{ background: `${group.color}15` }}>
+                  <Icon size={22} style={{ color: group.color }} />
                 </div>
-                <h3 className="text-sm font-bold text-center" style={{ color }}>
-                  {dept.name}
-                </h3>
-                <span
-                  className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold"
-                  style={{ background: badge.bg, color: badge.color }}
-                >
-                  {dept.status.charAt(0) + dept.status.slice(1).toLowerCase()}
-                </span>
+                <h3 className="text-base font-bold" style={{ color: group.color }}>{group.title}</h3>
               </div>
-
-              <div className="border-t border-gray-100 mb-3" />
-
-              {/* Stat rows */}
-              <div className="space-y-1">
-                {rows.map(row => (
-                  <div key={row.label} className="flex items-center gap-2.5 py-1">
-                    <div
-                      className="w-6 h-6 rounded-lg flex items-center justify-center shrink-0"
-                      style={{ background: `${color}12` }}
-                    >
-                      <row.icon size={12} style={{ color }} />
+              <div className="space-y-3 max-w-xs mx-auto">
+                {group.rows.map(row => {
+                  const RowIcon = row.icon;
+                  return (
+                    <div key={row.label} className="flex items-center gap-3">
+                      <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0" style={{ background: `${group.color}12` }}>
+                        <RowIcon size={14} style={{ color: group.color }} />
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        <span className="font-semibold text-gray-700">{row.label}:</span> {row.value}
+                      </p>
                     </div>
-                    <p className="text-xs text-gray-600 truncate">
-                      <span className="font-semibold text-gray-700">{row.label}:</span>{' '}
-                      {row.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-
-              {/* Actions */}
-              <div className="mt-3 flex justify-end">
-                <button className="text-gray-300 hover:text-gray-500 transition-colors p-1">
-                  <MoreVertical size={14} />
-                </button>
+                  );
+                })}
               </div>
             </div>
           );
         })}
       </div>
 
+      {/* Employee Directory */}
+      <div>
+        <h2 className="text-lg font-bold mb-4" style={{ color: NAVY }}>Employee Directory</h2>
+
+        {/* Filters */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 mb-1">Employee Details</label>
+            <div className="relative">
+              <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Type in a keyword or name ..."
+                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 mb-1">Department</label>
+            <select value={dept} onChange={e => setDept(e.target.value)} className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
+              {departments.map(d => <option key={d} value={d}>{d}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 mb-1">Availability</label>
+            <select value={availability} onChange={e => setAvailability(e.target.value)} className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option value="All">All</option>
+              <option value="Available">Available</option>
+              <option value="Unavailable">Unavailable</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left border-collapse min-w-[560px]">
+              <thead>
+                <tr className="border-b border-gray-100 text-xs font-semibold text-gray-500">
+                  <th className="px-6 py-3">Name</th>
+                  <th className="px-6 py-3">Department</th>
+                  <th className="px-6 py-3">Phone Number</th>
+                  <th className="px-6 py-3">Availability</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50 text-sm">
+                {filtered.length === 0 ? (
+                  <tr><td colSpan={4} className="px-6 py-10 text-center text-gray-400 font-medium">No employees found.</td></tr>
+                ) : filtered.map(emp => (
+                  <tr key={emp.name} className="hover:bg-gray-50/70 transition-colors">
+                    <td className="px-6 py-4 font-bold text-gray-900">{emp.name}</td>
+                    <td className="px-6 py-4 text-gray-600">{emp.department}</td>
+                    <td className="px-6 py-4 text-gray-600">{emp.phone}</td>
+                    <td className="px-6 py-4">
+                      <span
+                        className="inline-block px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider"
+                        style={emp.available ? { background: '#ECFDF5', color: '#15803D' } : { background: '#FEF2F2', color: '#DC2626' }}
+                      >
+                        {emp.available ? 'Available' : 'Unavailable'}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/hospital/admin/finance/page.tsx
+++ b/src/app/hospital/admin/finance/page.tsx
@@ -6,13 +6,12 @@ import {
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 
-import KpiCard from '@/components/hospital/finance/KpiCard';
 import RevenueChart from '@/components/hospital/finance/RevenueChart';
 import PaymentBreakdownChart from '@/components/hospital/finance/PaymentBreakdownChart';
 import InvoiceTable from '@/components/hospital/finance/InvoiceTable';
 import RefundTable from '@/components/hospital/finance/RefundTable';
 
-import { MOCK_FINANCE_KPIS, MOCK_INVOICES } from '@/mock/hospital/finance';
+import { MOCK_INVOICES } from '@/mock/hospital/finance';
 import type { PaymentBreakdownItem } from '@/components/hospital/finance/PaymentBreakdownChart';
 import type { RefundItem } from '@/components/hospital/finance/RefundTable';
 
@@ -38,11 +37,11 @@ const REFUNDS: RefundItem[] = [
   { id: 'RF-005', amount: 34_100, status: 'REJECTED', date: '2023-05-18' },
 ];
 
-const KPI_META = [
-  { icon: <BanknotesIcon className="w-5 h-5" />,        accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
-  { icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100', iconColor: 'text-red-500'     },
-  { icon: <BanknotesIcon className="w-5 h-5" />,        accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
-  { icon: <ClockIcon className="w-5 h-5" />,            accentColor: 'bg-amber-100',   iconColor: 'text-amber-600'   },
+const FINANCE_KPIS = [
+  { label: 'Total Revenues',   value: 'RWF 123,456', sub: '+12.5% from last week', trend: true,  icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
+  { label: 'Pending Payments', value: 'RWF 54,321',  sub: '18 Invoices',           trend: false, icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100',     iconColor: 'text-red-500'     },
+  { label: 'Overdue Payments', value: 'RWF 3,456',   sub: '9 Invoices',            trend: false, icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
+  { label: 'Refunds',          value: 'RWF 350,000', sub: '+24% from last week',   trend: true,  icon: <ClockIcon className="w-5 h-5" />,               accentColor: 'bg-purple-100',  iconColor: 'text-purple-600'  },
 ];
 
 export default function HospitalAdminFinancePage() {
@@ -53,7 +52,7 @@ export default function HospitalAdminFinancePage() {
       <div className="rounded-2xl p-7 bg-brand-hero relative overflow-hidden">
         <div className="relative z-10">
           <h1 className="text-3xl font-bold text-brand-navy">Finance</h1>
-          <p className="mt-1 text-sm text-slate-500">Overview of hospital finances and transactions</p>
+          <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Overview of hospital finances and transactions</p>
         </div>
         <svg
           className="absolute right-6 bottom-0 opacity-20 hidden sm:block"
@@ -70,17 +69,22 @@ export default function HospitalAdminFinancePage() {
 
       {/* KPI cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
-        {MOCK_FINANCE_KPIS.map((kpi, i) => (
-          <KpiCard
-            key={kpi.label}
-            label={kpi.label}
-            value={kpi.value}
-            trend={kpi.trend}
-            trendUp={kpi.trendUp}
-            icon={KPI_META[i].icon}
-            accentColor={KPI_META[i].accentColor}
-            iconColor={KPI_META[i].iconColor}
-          />
+        {FINANCE_KPIS.map((kpi) => (
+          <div key={kpi.label} className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 hover:shadow-md transition-shadow">
+            <div className="flex items-start justify-between">
+              <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${kpi.accentColor}`}>
+                <span className={kpi.iconColor}>{kpi.icon}</span>
+              </div>
+              <span className="text-gray-300 text-lg leading-none">⋯</span>
+            </div>
+            <p className="mt-3 text-sm font-semibold text-slate-600">{kpi.label}</p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{kpi.value}</p>
+            {kpi.trend ? (
+              <span className="mt-2 inline-block text-xs font-semibold px-2 py-0.5 rounded-md bg-emerald-50 text-emerald-700">{kpi.sub}</span>
+            ) : (
+              <span className="mt-2 inline-block text-xs text-slate-400">{kpi.sub}</span>
+            )}
+          </div>
         ))}
       </div>
 

--- a/src/app/hospital/admin/inventory/page.tsx
+++ b/src/app/hospital/admin/inventory/page.tsx
@@ -1,9 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { Hexagon, AlertTriangle, ClipboardList, Search } from 'lucide-react';
+
+type Category = 'Drug' | 'Supply' | 'Equipment';
+type Stock = 'IN_STOCK' | 'LOW_STOCK';
+type Alert = 'SAFE' | 'EXPIRING' | 'EXPIRED' | null;
+
+interface InventoryItem {
+  name: string;
+  category: Category;
+  quantity: number;
+  reorder: number;
+  expiry: string | null;
+  stock: Stock;
+  alert: Alert;
+  alertLabel?: string;
+}
+
+const ITEMS: InventoryItem[] = [
+  { name: 'Amoxicillin 500mg',      category: 'Drug',      quantity: 45,  reorder: 100, expiry: '2026-09-12', stock: 'LOW_STOCK', alert: 'SAFE' },
+  { name: 'Ibuprofen 400mg',        category: 'Drug',      quantity: 210, reorder: 50,  expiry: '2027-02-15', stock: 'IN_STOCK',  alert: 'SAFE' },
+  { name: 'Lisinopril 10mg',        category: 'Drug',      quantity: 12,  reorder: 20,  expiry: '2026-06-25', stock: 'LOW_STOCK', alert: 'EXPIRING', alertLabel: 'Expiring (35d)' },
+  { name: 'Surgical Sterile Gloves',category: 'Supply',    quantity: 850, reorder: 200, expiry: '2029-10-30', stock: 'IN_STOCK',  alert: 'SAFE' },
+  { name: 'N95 Respirator Masks',   category: 'Supply',    quantity: 80,  reorder: 150, expiry: '2026-04-10', stock: 'LOW_STOCK', alert: 'EXPIRED' },
+  { name: 'ECG Patient Monitor',    category: 'Equipment', quantity: 6,   reorder: 2,   expiry: null,         stock: 'IN_STOCK',  alert: null },
+  { name: 'Automated Defibrillator',category: 'Equipment', quantity: 1,   reorder: 2,   expiry: null,         stock: 'LOW_STOCK', alert: null },
+];
+
+const MODE_CARDS = [
+  { id: 'stock',       title: 'Hospital Stock',  desc: 'Track current drug supplies, equipment, and medical inventory levels.', icon: Hexagon,       color: '#2563EB' },
+  { id: 'alerts',      title: 'Alerts Queue',    desc: 'Instantly find expired, expiring, or critical low-stock items.',         icon: AlertTriangle, color: '#DC2626' },
+  { id: 'procurement', title: 'Procurement Log', desc: 'Submit and review procurement requests, tracking approval & delivery stages.', icon: ClipboardList, color: '#059669' },
+];
+
+const TABS: { key: string; label: string }[] = [
+  { key: 'ALL',       label: 'All Items' },
+  { key: 'Drug',      label: 'Drugs / Meds' },
+  { key: 'Supply',    label: 'Supplies' },
+  { key: 'Equipment', label: 'Equipment' },
+];
+
+const STOCK_STYLE: Record<Stock, { bg: string; color: string; dot: string; label: string }> = {
+  IN_STOCK:  { bg: '#ECFDF5', color: '#059669', dot: '#10B981', label: 'In Stock' },
+  LOW_STOCK: { bg: '#FEF2F2', color: '#DC2626', dot: '#EF4444', label: 'Low Stock' },
+};
+
+const ALERT_STYLE: Record<Exclude<Alert, null>, { bg: string; color: string; label: string }> = {
+  SAFE:     { bg: '#ECFDF5', color: '#15803D', label: 'Safe' },
+  EXPIRING: { bg: '#FFFBEB', color: '#C2410C', label: 'Expiring' },
+  EXPIRED:  { bg: '#FEF2F2', color: '#DC2626', label: 'Expired' },
+};
+
 export default function HospitalAdminInventoryPage() {
+  const [activeMode, setActiveMode] = useState('stock');
+  const [tab, setTab] = useState('ALL');
+  const [search, setSearch] = useState('');
+
+  const filtered = ITEMS.filter(i => {
+    if (tab !== 'ALL' && i.category !== tab) return false;
+    if (search.trim() && !i.name.toLowerCase().includes(search.trim().toLowerCase())) return false;
+    return true;
+  });
+
   return (
     <div className="space-y-6">
+      {/* Hero */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Inventory & Procurement</h1>
-        <p className="mt-1 text-sm font-medium" style={{ color: '#2D9B8A' }}>Manage hospital inventory and procurement</p>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Inventory Control &amp; Supply Chain</h1>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Track and manage hospital stock levels, alerts, and procurement requests</p>
+      </div>
+
+      {/* Mode cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {MODE_CARDS.map(card => {
+          const Icon = card.icon;
+          const active = activeMode === card.id;
+          return (
+            <button
+              key={card.id}
+              onClick={() => setActiveMode(card.id)}
+              className="bg-white rounded-2xl border p-6 flex flex-col items-center text-center transition-all hover:shadow-md"
+              style={{ borderColor: active ? card.color : '#F1F5F9', boxShadow: active ? `0 0 0 1px ${card.color}` : undefined }}
+            >
+              <Icon className="w-8 h-8 mb-3" style={{ color: card.color }} strokeWidth={1.6} />
+              <h3 className="text-sm font-bold text-gray-900">{card.title}</h3>
+              <p className="text-xs text-gray-400 mt-1 leading-relaxed max-w-[220px]">{card.desc}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tabs + search */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {TABS.map(tb => (
+            <button
+              key={tb.key}
+              onClick={() => setTab(tb.key)}
+              className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                tab === tb.key ? 'bg-blue-600 text-white' : 'bg-white border border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {tb.label}
+            </button>
+          ))}
+        </div>
+        <div className="relative w-full sm:w-72">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search stock inventory..."
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse min-w-[880px]">
+            <thead>
+              <tr className="border-b border-gray-100 text-[11px] font-bold text-gray-400 uppercase tracking-wider">
+                <th className="px-6 py-4">Item Name</th>
+                <th className="px-6 py-4">Category</th>
+                <th className="px-6 py-4">Available Quantity</th>
+                <th className="px-6 py-4">Min. Reorder Limit</th>
+                <th className="px-6 py-4">Expiry Date</th>
+                <th className="px-6 py-4">Status / Alerts</th>
+                <th className="px-6 py-4 text-right">Quick Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50 text-sm">
+              {filtered.length === 0 ? (
+                <tr><td colSpan={7} className="px-6 py-12 text-center text-gray-400 font-medium">No items found.</td></tr>
+              ) : filtered.map(item => {
+                const stock = STOCK_STYLE[item.stock];
+                const alert = item.alert ? ALERT_STYLE[item.alert] : null;
+                return (
+                  <tr key={item.name} className="hover:bg-gray-50/70 transition-colors">
+                    <td className="px-6 py-4 font-bold text-gray-900">{item.name}</td>
+                    <td className="px-6 py-4 text-gray-500">{item.category}</td>
+                    <td className="px-6 py-4 font-semibold text-gray-800">{item.quantity} units</td>
+                    <td className="px-6 py-4 text-gray-500">{item.reorder} units</td>
+                    <td className="px-6 py-4 text-gray-500">{item.expiry ?? '—'}</td>
+                    <td className="px-6 py-4">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider" style={{ background: stock.bg, color: stock.color }}>
+                          <span className="h-1.5 w-1.5 rounded-full" style={{ background: stock.dot }} />
+                          {stock.label}
+                        </span>
+                        {alert && (
+                          <span className="inline-block rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider" style={{ background: alert.bg, color: alert.color }}>
+                            {item.alertLabel ?? alert.label}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <button className="px-3 py-2 text-xs font-semibold text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap">
+                        Request Stock
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/app/hospital/admin/reports/page.tsx
+++ b/src/app/hospital/admin/reports/page.tsx
@@ -1,9 +1,136 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Cell,
+  PieChart, Pie,
+  RadarChart, PolarGrid, PolarAngleAxis, Radar,
+} from 'recharts';
+import { ClipboardDocumentListIcon } from '@heroicons/react/24/outline';
+
+const NAVY = '#1E4D8C';
+
+const WAIT_TIMES = [
+  { dept: 'Cardiology',   value: 42 },
+  { dept: 'Dermatology',  value: 30 },
+  { dept: 'Neurology',    value: 38 },
+  { dept: 'Orthopedics',  value: 55 },
+  { dept: 'Surgery',      value: 48 },
+  { dept: 'Gynecology',   value: 78 },
+];
+
+const SATISFACTION = [
+  { name: 'Excellent', value: 50, color: '#1E4D8C' },
+  { name: 'Good',      value: 35, color: '#3B82F6' },
+  { name: 'Poor',      value: 15, color: '#93C5FD' },
+];
+
+const STAFF_PER_DEPT = [
+  { dept: 'Cardiology',  value: 80 },
+  { dept: 'Surgery',     value: 65 },
+  { dept: 'Dermatology', value: 40 },
+  { dept: 'Gynecology',  value: 55 },
+  { dept: 'Orthopedics', value: 45 },
+  { dept: 'Neurology',   value: 60 },
+];
+
+const ADMITTED = [
+  { month: 'Jan', admitted: 4000, out: 2200 },
+  { month: 'Feb', admitted: 1600, out: 900 },
+  { month: 'Mar', admitted: 2400, out: 1600 },
+  { month: 'Apr', admitted: 3000, out: 1200 },
+  { month: 'May', admitted: 3400, out: 1800 },
+  { month: 'Jun', admitted: 1500, out: 900 },
+  { month: 'Jul', admitted: 1700, out: 1300 },
+  { month: 'Aug', admitted: 1400, out: 800 },
+  { month: 'Sep', admitted: 3700, out: 1500 },
+  { month: 'Oct', admitted: 3900, out: 2000 },
+];
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+      <h3 className="text-sm font-bold text-center mb-4" style={{ color: NAVY }}>{title}</h3>
+      <div className="h-64">{children}</div>
+    </div>
+  );
+}
+
 export default function HospitalAdminReportsPage() {
   return (
     <div className="space-y-6">
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Reports & Analysis</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
+      {/* Hero */}
+      <div className="rounded-2xl p-8 relative overflow-hidden" style={{ background: '#EBF5FF' }}>
+        <div className="relative z-10">
+          <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Reports &amp; Analysis</h1>
+          <p className="mt-1 text-sm font-semibold" style={{ color: '#0284C7' }}>Track the hospital reports and performance</p>
+          <button className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-white px-4 py-2 rounded-lg" style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}>
+            <ClipboardDocumentListIcon className="w-4 h-4" />
+            This Month
+          </button>
+        </div>
+        <svg className="absolute right-8 top-1/2 -translate-y-1/2 opacity-20 hidden sm:block" width="140" height="90" viewBox="0 0 140 90" fill="none">
+          <rect x="0"  y="60" width="20" height="30" rx="3" fill={NAVY} />
+          <rect x="30" y="45" width="20" height="45" rx="3" fill={NAVY} />
+          <rect x="60" y="55" width="20" height="35" rx="3" fill={NAVY} />
+          <rect x="90" y="30" width="20" height="60" rx="3" fill={NAVY} />
+          <polyline points="10,50 40,32 70,40 100,16 130,8" stroke={NAVY} strokeWidth="3" fill="none" strokeLinecap="round" />
+          <path d="M122,8 L130,8 L130,16" stroke={NAVY} strokeWidth="3" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </div>
+
+      {/* Charts grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <ChartCard title="Average wait times by Department">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={WAIT_TIMES} layout="vertical" margin={{ left: 20, right: 20 }}>
+              <CartesianGrid horizontal={false} stroke="#F1F5F9" />
+              <XAxis type="number" axisLine={false} tickLine={false} tick={{ fontSize: 11, fill: '#94A3B8' }} />
+              <YAxis type="category" dataKey="dept" axisLine={false} tickLine={false} width={80} tick={{ fontSize: 10, fill: '#64748B' }} />
+              <Tooltip cursor={{ fill: '#F8FAFC' }} />
+              <Bar dataKey="value" fill="#93C5FD" radius={[0, 6, 6, 0]} barSize={14} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Patient Satisfaction">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie data={SATISFACTION} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={55} outerRadius={85} paddingAngle={2}>
+                {SATISFACTION.map((s) => <Cell key={s.name} fill={s.color} />)}
+              </Pie>
+              <Legend verticalAlign="bottom" height={24} iconType="square" formatter={(value) => {
+                const item = SATISFACTION.find(s => s.name === value);
+                return <span className="text-xs text-gray-500">{value} {item?.value}%</span>;
+              }} />
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Staff Per Department">
+          <ResponsiveContainer width="100%" height="100%">
+            <RadarChart data={STAFF_PER_DEPT} outerRadius="70%">
+              <PolarGrid stroke="#E2E8F0" />
+              <PolarAngleAxis dataKey="dept" tick={{ fontSize: 10, fill: '#64748B' }} />
+              <Radar dataKey="value" stroke="#2563EB" fill="#3B82F6" fillOpacity={0.3} />
+            </RadarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+
+        <ChartCard title="Admitted Patients over time">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={ADMITTED} margin={{ top: 8 }}>
+              <CartesianGrid vertical={false} stroke="#F1F5F9" />
+              <XAxis dataKey="month" axisLine={false} tickLine={false} tick={{ fontSize: 10, fill: '#94A3B8' }} />
+              <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 10, fill: '#94A3B8' }} />
+              <Tooltip cursor={{ fill: '#F8FAFC' }} />
+              <Legend verticalAlign="bottom" height={24} iconType="square" formatter={(v) => <span className="text-xs text-gray-500">{v}</span>} />
+              <Bar dataKey="admitted" name="Admitted Patients" fill="#1E4D8C" radius={[3, 3, 0, 0]} barSize={10} />
+              <Bar dataKey="out" name="OutPatients" fill="#7DD3FC" radius={[3, 3, 0, 0]} barSize={10} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
       </div>
     </div>
   );

--- a/src/app/hospital/admin/schedule/page.tsx
+++ b/src/app/hospital/admin/schedule/page.tsx
@@ -1,10 +1,259 @@
+'use client';
+
+import { useState } from 'react';
+import {
+    startOfWeek,
+    endOfWeek,
+    startOfMonth,
+    endOfMonth,
+    eachDayOfInterval,
+    addDays,
+    addWeeks,
+    subWeeks,
+    addMonths,
+    subMonths,
+    isSameMonth,
+    isSameDay,
+    format,
+    isToday,
+} from 'date-fns';
+import {
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    ChevronUpIcon,
+    PlusIcon,
+    CalendarIcon,
+    MagnifyingGlassIcon,
+    Cog6ToothIcon,
+    VideoCameraIcon,
+    UserIcon,
+    UsersIcon,
+} from '@heroicons/react/24/outline';
+import { MOCK_SCHEDULE } from '@/mock/hospital/schedule';
+import { EntryColor } from '@/types/hospital';
+
+const COLOR_MAP: Record<EntryColor, string> = {
+    blue: 'bg-blue-50 text-blue-700 border-blue-200',
+    green: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    orange: 'bg-orange-50 text-orange-700 border-orange-200',
+    purple: 'bg-purple-50 text-purple-700 border-purple-200',
+    red: 'bg-red-50 text-red-700 border-red-200',
+};
+
+const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+function hourLabel(h: number) {
+    const period = h < 12 ? 'AM' : 'PM';
+    const display = h % 12 === 0 ? 12 : h % 12;
+    return `${display} ${period}`;
+}
+
+function startHour(entry: { startTime?: string }) {
+    return entry.startTime ? parseInt(entry.startTime.split(':')[0], 10) : -1;
+}
+
+function MiniCalendar({ selected, onSelect }: { selected: Date; onSelect: (d: Date) => void }) {
+    const [month, setMonth] = useState(selected);
+    const gridStart = startOfWeek(startOfMonth(month), { weekStartsOn: 0 });
+    const gridEnd = endOfWeek(endOfMonth(month), { weekStartsOn: 0 });
+    const days = eachDayOfInterval({ start: gridStart, end: gridEnd });
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-bold text-gray-700">{format(month, 'MMMM yyyy')}</span>
+                <div className="flex items-center gap-1">
+                    <button onClick={() => setMonth(subMonths(month, 1))} className="p-1 rounded hover:bg-gray-100">
+                        <ChevronLeftIcon className="w-3.5 h-3.5 text-gray-400" />
+                    </button>
+                    <button onClick={() => setMonth(addMonths(month, 1))} className="p-1 rounded hover:bg-gray-100">
+                        <ChevronRightIcon className="w-3.5 h-3.5 text-gray-400" />
+                    </button>
+                </div>
+            </div>
+            <div className="grid grid-cols-7 text-center text-[10px] font-semibold text-gray-400 mb-1">
+                {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => <span key={i}>{d}</span>)}
+            </div>
+            <div className="grid grid-cols-7 gap-y-1 text-center text-[11px]">
+                {days.map((day) => {
+                    const muted = !isSameMonth(day, month);
+                    const sel = isSameDay(day, selected);
+                    const today = isToday(day);
+                    return (
+                        <button
+                            key={day.toISOString()}
+                            onClick={() => onSelect(day)}
+                            className={`w-6 h-6 mx-auto rounded-full flex items-center justify-center transition-colors ${
+                                sel ? 'bg-blue-600 text-white font-bold'
+                                    : today ? 'text-blue-600 font-bold'
+                                    : muted ? 'text-gray-300'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            {format(day, 'd')}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
 export default function HospitalAdminSchedulePage() {
-  return (
-    <div className="space-y-6">
-      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Schedule</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
-      </div>
-    </div>
-  );
+    const [currentDate, setCurrentDate] = useState(new Date('2026-06-01'));
+    const [viewMode, setViewMode] = useState<'WEEK' | 'MONTH'>('WEEK');
+
+    const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 });
+    const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+    const monthDays = eachDayOfInterval({ start: startOfMonth(currentDate), end: endOfMonth(currentDate) });
+
+    const dayKey = (d: Date) => format(d, 'yyyy-MM-dd');
+    const entryAt = (d: Date, hour: number) =>
+        MOCK_SCHEDULE.find((e) => e.date === dayKey(d) && startHour(e) === hour);
+    const entriesForDay = (d: Date) => MOCK_SCHEDULE.filter((e) => e.date === dayKey(d));
+
+    const typeMeta = (type?: string) =>
+        type === 'ONLINE'
+            ? { label: 'Video Call', Icon: VideoCameraIcon }
+            : { label: 'In-Person', Icon: UserIcon };
+
+    const goPrev = () => viewMode === 'WEEK' ? setCurrentDate(subWeeks(currentDate, 1)) : setCurrentDate(subMonths(currentDate, 1));
+    const goNext = () => viewMode === 'WEEK' ? setCurrentDate(addWeeks(currentDate, 1)) : setCurrentDate(addMonths(currentDate, 1));
+
+    return (
+        <div className="space-y-6">
+            {/* Hero */}
+            <div className="rounded-2xl px-8 py-7" style={{ background: '#EBF5FF' }}>
+                <h1 className="text-2xl sm:text-3xl font-bold uppercase tracking-tight" style={{ color: '#1E3A5F' }}>Schedule</h1>
+                <p className="mt-1 text-xs font-semibold" style={{ color: '#0284C7' }}>Select Date and Time</p>
+                <button className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-white px-4 py-2 rounded-lg" style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}>
+                    <CalendarIcon className="w-4 h-4" />
+                    This Week
+                </button>
+            </div>
+
+            {/* Controls */}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-1 bg-white border border-gray-200 p-1 rounded-xl">
+                    <button onClick={() => setViewMode('WEEK')} className={`px-5 py-1.5 rounded-lg text-sm font-semibold transition-all ${viewMode === 'WEEK' ? 'bg-blue-50 text-blue-600' : 'text-gray-500'}`}>Week</button>
+                    <button onClick={() => setViewMode('MONTH')} className={`px-5 py-1.5 rounded-lg text-sm font-semibold transition-all ${viewMode === 'MONTH' ? 'bg-blue-50 text-blue-600' : 'text-gray-500'}`}>Month</button>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <button onClick={goPrev} className="p-2 rounded-lg border border-gray-200 hover:bg-gray-50"><ChevronLeftIcon className="w-4 h-4 text-gray-600" /></button>
+                    <span className="text-sm font-semibold text-gray-700 min-w-[180px] text-center">
+                        {viewMode === 'WEEK' ? `${format(weekDays[0], 'MMM d')} - ${format(weekDays[6], 'MMM d, yyyy')}` : format(currentDate, 'MMMM yyyy')}
+                    </span>
+                    <button onClick={goNext} className="p-2 rounded-lg border border-gray-200 hover:bg-gray-50"><ChevronRightIcon className="w-4 h-4 text-gray-600" /></button>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <button className="p-2 rounded-lg hover:bg-gray-100 text-gray-500"><MagnifyingGlassIcon className="w-5 h-5" /></button>
+                    <button className="p-2 rounded-lg hover:bg-gray-100 text-gray-500"><Cog6ToothIcon className="w-5 h-5" /></button>
+                </div>
+            </div>
+
+            {/* Calendar + sidebar */}
+            <div className="flex flex-col lg:flex-row gap-6">
+                <aside className="w-full lg:w-60 shrink-0 bg-white rounded-2xl border border-gray-100 shadow-sm p-4 space-y-5">
+                    <MiniCalendar selected={currentDate} onSelect={setCurrentDate} />
+                    <div className="relative">
+                        <UsersIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                        <input type="text" placeholder="Search for people" className="w-full pl-9 pr-3 py-2 text-xs bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400" />
+                    </div>
+                    <button className="w-full flex items-center justify-between text-sm font-semibold text-gray-700 hover:text-gray-900">
+                        <span>Booking Pages</span>
+                        <PlusIcon className="w-4 h-4 text-gray-400" />
+                    </button>
+                    <div>
+                        <div className="flex items-center justify-between text-sm font-semibold text-gray-700 mb-2">
+                            <span>My calendars</span>
+                            <ChevronUpIcon className="w-4 h-4 text-gray-400" />
+                        </div>
+                        <div className="flex items-center gap-2 pl-1">
+                            <span className="w-3.5 h-3.5 rounded-sm shrink-0" style={{ background: '#22D3EE' }} />
+                            <span className="text-xs text-gray-600 flex-1 truncate">Hospital Admin</span>
+                        </div>
+                    </div>
+                    <div className="flex items-center justify-between text-sm font-semibold text-gray-700">
+                        <span>Other calendars</span>
+                        <div className="flex items-center gap-1">
+                            <PlusIcon className="w-4 h-4 text-gray-400" />
+                            <ChevronUpIcon className="w-4 h-4 text-gray-400" />
+                        </div>
+                    </div>
+                </aside>
+
+                <div className="flex-1 min-w-0 bg-white rounded-2xl border border-gray-100 shadow-sm overflow-x-auto">
+                    {viewMode === 'WEEK' ? (
+                        <div className="min-w-[640px]">
+                            <div className="grid border-b border-gray-100" style={{ gridTemplateColumns: '56px repeat(7, 1fr)' }}>
+                                <div className="py-3" />
+                                {weekDays.map((day) => {
+                                    const todayCol = isToday(day);
+                                    return (
+                                        <div key={day.toISOString()} className="py-3 text-center border-l border-gray-100 flex items-center justify-center gap-2">
+                                            <span className={`text-[11px] font-bold uppercase tracking-wider ${todayCol ? 'text-blue-600' : 'text-gray-400'}`}>{format(day, 'EEE')}</span>
+                                            <span className={`text-sm font-bold inline-flex items-center justify-center w-7 h-7 rounded-full ${todayCol ? 'bg-blue-600 text-white' : 'text-gray-700'}`}>{format(day, 'd')}</span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                            {HOURS.map((hour) => (
+                                <div key={hour} className="grid border-b border-gray-50 last:border-0" style={{ gridTemplateColumns: '56px repeat(7, 1fr)' }}>
+                                    <div className="py-4 pr-2 text-right text-[11px] font-semibold text-gray-400">{hourLabel(hour)}</div>
+                                    {weekDays.map((day) => {
+                                        const entry = entryAt(day, hour);
+                                        return (
+                                            <div key={day.toISOString()} className="min-h-[72px] border-l border-gray-100 p-1.5">
+                                                {entry && (() => {
+                                                    const meta = typeMeta(entry.type);
+                                                    const accent = COLOR_MAP[entry.color] ?? COLOR_MAP.blue;
+                                                    return (
+                                                        <div className={`h-full rounded-lg border p-2 ${accent}`}>
+                                                            <p className="text-[10px] font-semibold opacity-80">{entry.startTime && format(new Date(`2026-01-01T${entry.startTime}`), 'h:mm a')}</p>
+                                                            <p className="text-xs font-bold leading-tight mt-0.5 truncate">{entry.doctorName ?? entry.patientName}</p>
+                                                            <p className="flex items-center gap-1 text-[10px] font-medium opacity-80 mt-1"><meta.Icon className="w-3 h-3" />{meta.label}</p>
+                                                        </div>
+                                                    );
+                                                })()}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div>
+                            <div className="grid grid-cols-7 bg-gray-50 border-b border-gray-100">
+                                {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(d => (
+                                    <div key={d} className="py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">{d}</div>
+                                ))}
+                            </div>
+                            <div className="grid grid-cols-7">
+                                {Array.from({ length: (startOfWeek(startOfMonth(currentDate), { weekStartsOn: 1 }).getDay() + 6) % 7 }).map((_, i) => (
+                                    <div key={`pad-${i}`} className="h-28 border-b border-r border-gray-50" />
+                                ))}
+                                {monthDays.map((day) => {
+                                    const entries = entriesForDay(day);
+                                    const todayCell = isToday(day);
+                                    return (
+                                        <div key={day.toISOString()} className={`h-28 p-2 border-b border-r border-gray-100 ${todayCell ? 'bg-blue-50/40' : ''}`}>
+                                            <span className={`text-sm font-bold ${todayCell ? 'text-blue-600' : 'text-gray-700'}`}>{format(day, 'd')}</span>
+                                            {entries.length > 0 && (
+                                                <div className="mt-1 inline-flex items-center gap-1 bg-blue-600 text-white rounded-md px-2 py-0.5">
+                                                    <span className="text-[10px] font-bold">{entries.length}</span>
+                                                    <span className="text-[10px]">visits</span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/app/hospital/admin/settings/page.tsx
+++ b/src/app/hospital/admin/settings/page.tsx
@@ -21,7 +21,6 @@ import {
 } from '@/mock/hospital/settings';
 
 const NAVY     = '#1E3A5F';
-const TEAL     = '#2D9B8A';
 const GRADIENT = 'linear-gradient(90deg, #1E4D8C 0%, #2D9B8A 100%)';
 
 type Tab = 'general' | 'fees' | 'announcements' | 'departments';
@@ -56,7 +55,7 @@ export default function HospitalAdminSettingsPage() {
           <h1 className="text-2xl sm:text-3xl font-semibold truncate" style={{ color: NAVY }}>
             Settings
           </h1>
-          <p className="mt-1 text-sm font-medium" style={{ color: TEAL }}>
+          <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>
             Manage Hospital Preferences and Configurations
           </p>
         </div>
@@ -80,7 +79,7 @@ export default function HospitalAdminSettingsPage() {
               style={{
                 whiteSpace: 'nowrap',
                 ...(activeTab === key
-                  ? { background: GRADIENT, color: '#fff' }
+                  ? { background: '#EFF6FF', color: '#2563EB', border: '1px solid #BFDBFE' }
                   : { background: '#fff', color: '#6b7280', border: '1px solid #d1d5db' }),
               }}
             >
@@ -93,7 +92,7 @@ export default function HospitalAdminSettingsPage() {
         {/* Fix 4: full-width on mobile, auto on sm+ */}
         <button
           className="flex items-center justify-center gap-2 w-full sm:w-auto px-5 py-2.5 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-all min-h-11 shrink-0"
-          style={{ background: GRADIENT }}
+          style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}
         >
           <Save size={15} />
           Save Changes
@@ -140,8 +139,8 @@ function ActionBtn({ label, onClick }: { label: string; onClick?: () => void }) 
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1 text-xs font-semibold text-white px-3 py-1.5 rounded-lg hover:opacity-90 transition-all whitespace-nowrap"
-      style={{ background: GRADIENT }}
+      className="flex items-center gap-1 text-xs font-semibold px-3 py-1.5 rounded-lg hover:opacity-90 transition-all whitespace-nowrap"
+      style={{ background: '#EFF6FF', color: '#2563EB' }}
     >
       <Plus size={12} />
       {label}

--- a/src/app/hospital/admin/staff/page.tsx
+++ b/src/app/hospital/admin/staff/page.tsx
@@ -164,7 +164,7 @@ export default function HospitalAdminStaffManagementPage() {
       <div className="rounded-2xl px-6 py-7 flex items-center justify-between" style={{ background: '#EBF5FF' }}>
         <div>
           <h1 className="text-2xl sm:text-3xl font-bold" style={{ color: NAVY }}>Staff Management</h1>
-          <p className="mt-1 text-sm font-medium" style={{ color: TEAL }}>Manage Hospital Staff, roles and departments.</p>
+          <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Manage Hospital Staff, roles and departments.</p>
         </div>
         <div className="opacity-10 shrink-0 ml-4 hidden sm:block" style={{ color: NAVY }}>
           <Users size={60} />

--- a/src/app/hospital/doctor/appointments/page.tsx
+++ b/src/app/hospital/doctor/appointments/page.tsx
@@ -14,12 +14,18 @@ import {
   ClockIcon,
   MagnifyingGlassIcon,
   FunnelIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  EllipsisVerticalIcon,
 } from '@heroicons/react/24/outline';
+
+const PAGE_SIZE = 8;
 
 export default function HospitalDoctorAppointmentsPage() {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTab, setActiveTab] = useState<string>('ALL');
+  const [page, setPage] = useState(1);
 
   const totalCount = MOCK_APPOINTMENTS.length;
   const confirmedCount = MOCK_APPOINTMENTS.filter((a) => a.status === 'CONFIRMED').length;
@@ -28,8 +34,8 @@ export default function HospitalDoctorAppointmentsPage() {
 
   //stats
   const statCards = [
-    { label: t('hospital.total', 'Total'), value: totalCount, icon: CalendarIcon, iconColor: '#1E4D8C', bgColor: '#EBF5FF' },
-    { label: t('hospital.confirmed', 'Confirmed'), value: confirmedCount, icon: ClockIcon, iconColor: '#0284C7', bgColor: '#E0F2FE' },
+    { label: t('hospital.today', 'Today'), value: totalCount, icon: CalendarIcon, iconColor: '#7C3AED', bgColor: '#F3E8FF' },
+    { label: t('hospital.upcoming', 'Upcoming'), value: confirmedCount, icon: ClockIcon, iconColor: '#0284C7', bgColor: '#E0F2FE' },
     { label: t('hospital.completed', 'Completed'), value: completedCount, icon: CheckCircleIcon, iconColor: '#16A34A', bgColor: '#DCFCE7' },
     { label: t('hospital.cancelled', 'Cancelled'), value: cancelledCount, icon: XCircleIcon, iconColor: '#EA580C', bgColor: '#FEE2E2' },
   ];
@@ -51,7 +57,10 @@ export default function HospitalDoctorAppointmentsPage() {
     return matchesTab && matchesSearch;
   });
 
-  const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString();
+  const totalPages = Math.max(1, Math.ceil(filteredAppointments.length / PAGE_SIZE));
+  const safePage   = Math.min(page, totalPages);
+  const pageItems  = filteredAppointments.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
   const formatTime = (dateString: string) => new Date(dateString).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
     //statusMap for appointments
@@ -68,8 +77,8 @@ export default function HospitalDoctorAppointmentsPage() {
     <div className="space-y-6">
       {/* Hero Header */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
-        <h1 className="text-3xl font-extrabold text-gray-900">{t('hospital.appointmentsTitle', 'Appointment Scheduling & Tracking')}</h1>
-        <p className="mt-1 text-sm text-gray-600">{t('hospital.appointmentsSubtitle', 'Manage and track patient consultation timelines')}</p>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>{t('hospital.appointmentsTitle', 'Appointments')}</h1>
+        <p className="mt-1 text-sm" style={{ color: '#3B82F6' }}>{t('hospital.appointmentsSubtitle', 'Manage and track patients appointments')}</p>
       </div>
 
       {/* Stats Cards Section */}
@@ -77,13 +86,16 @@ export default function HospitalDoctorAppointmentsPage() {
         {statCards.map((stat) => {
           const Icon = stat.icon;
           return (
-            <div key={stat.label} className="bg-white rounded-2xl border border-gray-200 p-5 shadow-sm flex items-center justify-between">
-              <div>
-                <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{stat.label}</h3>
-                <p className="mt-1 text-3xl font-bold text-gray-900">{stat.value}</p>
-              </div>
-              <div className="rounded-xl p-3 shrink-0" style={{ backgroundColor: stat.bgColor }}>
-                <Icon className="w-6 h-6" style={{ color: stat.iconColor }} />
+            <div key={stat.label} className="bg-white rounded-2xl border border-gray-200 p-5 shadow-sm">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700">{stat.label}</h3>
+                  <p className="mt-2 text-3xl font-bold text-gray-900">{stat.value}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{t('hospital.appointmentsWord', 'Appointments')}</p>
+                </div>
+                <div className="rounded-xl p-2.5 shrink-0" style={{ backgroundColor: stat.bgColor }}>
+                  <Icon className="w-5 h-5" style={{ color: stat.iconColor }} />
+                </div>
               </div>
             </div>
           );
@@ -98,7 +110,7 @@ export default function HospitalDoctorAppointmentsPage() {
             type="text"
             placeholder={t('hospital.searchPlaceholder', 'Search name by ID, condition...')}
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => { setSearchTerm(e.target.value); setPage(1); }}
             className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-xl text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none"
           />
         </div>
@@ -110,7 +122,7 @@ export default function HospitalDoctorAppointmentsPage() {
               return (
                 <button
                   key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
+                  onClick={() => { setActiveTab(tab.id); setPage(1); }}
                   className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all flex items-center gap-1.5 ${
                     activeTab === tab.id
                       ? 'bg-blue-600 text-white shadow-sm'
@@ -136,35 +148,35 @@ export default function HospitalDoctorAppointmentsPage() {
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200 text-xs font-bold text-gray-500 uppercase tracking-wider">
                 <th className="px-6 py-4">{t('hospital.thPatient', 'Patient')}</th>
-                <th className="px-6 py-4">{t('hospital.thDate', 'Date')}</th>
                 <th className="px-6 py-4">{t('hospital.thTime', 'Time')}</th>
-                <th className="px-6 py-4">{t('hospital.thSpecialization', 'Specialization')}</th>
-                <th className="px-6 py-4">{t('hospital.thType', 'Type')}</th>
+                <th className="px-6 py-4">{t('hospital.thType', 'Appointment type')}</th>
+                <th className="px-6 py-4">{t('hospital.thDoctor', 'Doctor')}</th>
+                <th className="px-6 py-4">{t('hospital.thNotes', 'Notes')}</th>
                 <th className="px-6 py-4">{t('hospital.thStatus', 'Status')}</th>
-                <th className="px-6 py-4 text-right">{t('hospital.thActions', 'Actions')}</th>
+                <th className="px-6 py-4 text-right" />
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100 text-sm">
-              {filteredAppointments.length === 0 ? (
+              {pageItems.length === 0 ? (
                 <tr>
                   <td colSpan={7} className="text-center py-12 text-gray-400 font-medium">
                     {t('hospital.noAppointmentsFound', 'No appointments found matching the selected criteria.')}
                   </td>
                 </tr>
               ) : (
-                filteredAppointments.map((apt: Appointment) => (
+                pageItems.map((apt: Appointment) => (
                   <tr key={apt.id} className="hover:bg-gray-50/70 transition-colors">
                     <td className="px-6 py-4 font-semibold text-gray-900">
                       {apt.patientName}
                     </td>
-                    <td className="px-6 py-4 text-gray-600">{formatDate(apt.date)}</td>
                     <td className="px-6 py-4 text-gray-600">{formatTime(apt.date)}</td>
                     <td className="px-6 py-4">
                       <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-md text-xs font-medium">
                         {apt.specialization || t('hospital.general', 'General')}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-gray-600 capitalize">{apt.type?.toLowerCase().replace('_', '-')}</td>
+                    <td className="px-6 py-4 text-gray-600">{apt.doctorName}</td>
+                    <td className="px-6 py-4 text-gray-500 max-w-[220px] truncate">{apt.notes ?? apt.reason}</td>
                     <td className="px-6 py-4">
                       {(() => {
                         const status = statusMap[apt.status] ?? {
@@ -185,9 +197,10 @@ export default function HospitalDoctorAppointmentsPage() {
                     <td className="px-6 py-4 text-right">
                       <Link
                         href={`/hospital/doctor/appointments/${apt.id}`}
-                        className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-semibold rounded-xl bg-white text-gray-700 hover:bg-gray-50 transition-all shadow-sm"
+                        aria-label={t('hospital.viewBtn', 'View')}
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
                       >
-                        {t('hospital.viewBtn', 'View')}
+                        <EllipsisVerticalIcon className="w-5 h-5" />
                       </Link>
                     </td>
                   </tr>
@@ -196,10 +209,60 @@ export default function HospitalDoctorAppointmentsPage() {
             </tbody>
           </table>
         </div>
-        <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 text-xs text-gray-500">
-          {t('hospital.showingCount', 'Showing {{count}} of {{total}} Appointments', { count: filteredAppointments.length, total: totalCount })}
+        <div className="flex items-center justify-between px-6 py-4 bg-gray-50 border-t border-gray-200 text-xs text-gray-500">
+          <span>
+            {t('hospital.showingCount', 'Showing {{count}} of {{total}} Appointments', { count: pageItems.length, total: filteredAppointments.length })}
+          </span>
+          <div className="flex items-center gap-1">
+            <AptNavButton onClick={() => setPage(p => Math.max(1, p - 1))} disabled={safePage === 1}>
+              <ChevronLeftIcon className="w-3.5 h-3.5" />
+            </AptNavButton>
+            {aptPageNumbers(safePage, totalPages).map((n, i) =>
+              n === '...'
+                ? <span key={`ellipsis-${i}`} className="px-1 text-gray-400">...</span>
+                : <AptPageButton key={n} label={n} active={n === safePage} onClick={() => setPage(n)} />
+            )}
+            <AptNavButton onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={safePage === totalPages}>
+              <ChevronRightIcon className="w-3.5 h-3.5" />
+            </AptNavButton>
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+function aptPageNumbers(current: number, total: number): (number | '...')[] {
+  if (total <= 5) return Array.from({ length: total }, (_, i) => i + 1);
+  const pages: (number | '...')[] = [1];
+  if (current > 3) pages.push('...');
+  for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) pages.push(i);
+  if (current < total - 2) pages.push('...');
+  pages.push(total);
+  return pages;
+}
+
+function AptPageButton({ label, active, onClick }: { label: number; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-7 h-7 text-xs rounded flex items-center justify-center transition-colors ${
+        active ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function AptNavButton({ onClick, disabled, children }: { onClick: () => void; disabled: boolean; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="w-7 h-7 flex items-center justify-center rounded transition-colors disabled:text-gray-300 disabled:cursor-default text-gray-600 hover:bg-gray-100 disabled:hover:bg-transparent"
+    >
+      {children}
+    </button>
   );
 }

--- a/src/app/hospital/doctor/appointments/page.tsx
+++ b/src/app/hospital/doctor/appointments/page.tsx
@@ -78,7 +78,7 @@ export default function HospitalDoctorAppointmentsPage() {
       {/* Hero Header */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
         <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>{t('hospital.appointmentsTitle', 'Appointments')}</h1>
-        <p className="mt-1 text-sm" style={{ color: '#3B82F6' }}>{t('hospital.appointmentsSubtitle', 'Manage and track patients appointments')}</p>
+        <p className="mt-1 text-sm" style={{ color: '#0284C7' }}>{t('hospital.appointmentsSubtitle', 'Manage and track patients appointments')}</p>
       </div>
 
       {/* Stats Cards Section */}

--- a/src/app/hospital/doctor/consultations/page.tsx
+++ b/src/app/hospital/doctor/consultations/page.tsx
@@ -27,7 +27,7 @@ export default function HospitalDoctorConsultationsPage() {
         <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>
           Patient Consultations Workflow
         </h1>
-        <p className="mt-1 text-sm" style={{ color: '#00A2E8' }}>
+        <p className="mt-1 text-sm" style={{ color: '#0284C7' }}>
           Record medical examinations, patient vitals, diagnosis codes, and treatment instructions.
         </p>
       </div>

--- a/src/app/hospital/doctor/dashboard/page.tsx
+++ b/src/app/hospital/doctor/dashboard/page.tsx
@@ -84,13 +84,14 @@ export default function HospitalDoctorDashboardPage() {
   });
 
   const patientCategoryTotal = MOCK_PATIENT_CATEGORIES.reduce((sum, item) => sum + item.value, 0);
-  let startPercentage = 0;
-  const categoryGradient = `conic-gradient(${MOCK_PATIENT_CATEGORIES.map((item) => {
-    const endPercentage = startPercentage + (item.value / patientCategoryTotal) * 100;
-    const result = `${item.color} ${startPercentage}% ${endPercentage}%`;
-    startPercentage = endPercentage;
-    return result;
-  }).join(', ')})`;
+  const categorySegments = MOCK_PATIENT_CATEGORIES.map((item, index) => {
+    const start = MOCK_PATIENT_CATEGORIES
+      .slice(0, index)
+      .reduce((sum, c) => sum + (c.value / patientCategoryTotal) * 100, 0);
+    const end = start + (item.value / patientCategoryTotal) * 100;
+    return `${item.color} ${start}% ${end}%`;
+  });
+  const categoryGradient = `conic-gradient(${categorySegments.join(', ')})`;
 
   const priorityBadgeClasses: Record<string, string> = {
     Low: 'bg-emerald-100 text-emerald-700',

--- a/src/app/hospital/doctor/dashboard/page.tsx
+++ b/src/app/hospital/doctor/dashboard/page.tsx
@@ -24,35 +24,51 @@ export default function HospitalDoctorDashboardPage() {
   const overviewCards = [
     {
       title: MOCK_DASHBOARD_STATS.appointmentsByStatus.CONFIRMED + MOCK_DASHBOARD_STATS.appointmentsByStatus.PENDING,
-      label: t('hospital.todayAppointments'),
+      label: 'Appointments',
+      trend: '+2 than yesterday',
       icon: CalendarIcon,
       borderColor: '#E0F2FE',
       iconColor: '#0284C7',
-      iconBg: '#EBF5FF'
+      iconBg: '#EBF5FF',
+      labelColor: '#0284C7',
+      pillBg: '#EBF5FF',
+      pillColor: '#0284C7',
     },
     {
       title: MOCK_DASHBOARD_STATS.totalPatients,
-      label: t('hospital.totalPatients'),
+      label: 'Total Patients',
+      trend: '10% last month',
       icon: UsersIcon,
       borderColor: '#DCFCE7',
       iconColor: '#04802D',
-      iconBg: '#F0FDF4'
+      iconBg: '#F0FDF4',
+      labelColor: '#04802D',
+      pillBg: '#F0FDF4',
+      pillColor: '#04802D',
     },
     {
-      title: MOCK_DASHBOARD_STATS.activeDoctors,
-      label: t('hospital.activeDoctors'),
+      title: 2,
+      label: 'Emergency Cases',
+      trend: '+2% this week',
       icon: UserPlusIcon,
       borderColor: '#FEE2E2',
       iconColor: '#FF0000',
-      iconBg: '#FEF2F2'
+      iconBg: '#FEF2F2',
+      labelColor: '#DC2626',
+      pillBg: '#FEF2F2',
+      pillColor: '#DC2626',
     },
     {
-      title: MOCK_DASHBOARD_STATS.monthlyRevenue.toLocaleString('en-US', { style: 'currency', currency: 'USD' }),
-      label: t('hospital.monthlyRevenue'),
+      title: '40%',
+      label: 'Medicine Stock Rate',
+      trend: 'this month',
       icon: BanknotesIcon,
       borderColor: '#F3E8FF',
       iconColor: '#92009F',
-      iconBg: '#F3E8FF'
+      iconBg: '#F3E8FF',
+      labelColor: '#92009F',
+      pillBg: '#F3E8FF',
+      pillColor: '#92009F',
     }
   ];
 
@@ -103,36 +119,24 @@ export default function HospitalDoctorDashboardPage() {
   return (
     <div className="space-y-6">
       {/* Hero*/}
-      <div className="rounded-2xl relative overflow-hidden w-full" style={{ background: '#EBF5FF', padding: '28px 48px' }}>
-        {/*Heartbeat SVG*/}
-        <svg 
-          className="absolute right-0 top-1/2 -translate-y-1/2 opacity-10 pointer-events-none hidden sm:block sm:w-48 md:w-64 lg:w-96 xl:w-[500px]" 
-          viewBox="0 0 320 140" 
-          fill="none"
-          preserveAspectRatio="xMidYMid meet"
+      <div className="rounded-2xl w-full" style={{ background: '#EBF5FF', padding: '26px 32px' }}>
+        <h1 className="text-2xl sm:text-3xl font-bold mb-2" style={{ color: '#1a3470' }}>
+          {getGreeting()}, Dr. {firstName}
+        </h1>
+        <p className="text-sm sm:text-base" style={{ color: '#0284C7' }}>{t('hospital.welcomeMessage')}</p>
+        <Link
+          href="/hospital/doctor/appointments"
+          className="mt-5 inline-flex items-center justify-center gap-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+          style={{
+            background: 'linear-gradient(to right, #0284C7, #38BDF8)',
+            height: '38px',
+            borderRadius: '12px',
+            padding: '0 18px',
+          }}
         >
-          <polyline points="0,70 55,70 80,15 108,125 135,30 162,105 188,70 320,70" stroke="#1E4D8C" strokeWidth="7" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-
-        <div className="relative z-10">
-          <h1 className="text-4xl sm:text-5xl font-black mb-3" style={{ color: '#1a3470' }}>
-            {getGreeting()},{firstName}.
-          </h1>
-          <p className="text-lg" style={{ color: '#0284C7' }}>{t('hospital.welcomeMessage')}</p>
-          <Link
-            href="/hospital/doctor/appointments"
-            className="mt-6 inline-flex items-center justify-center gap-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
-            style={{
-              background: 'linear-gradient(to right, #0284C7, #38BDF8)',
-              width: '140px',
-              height: '44px',
-              borderRadius: '16px',
-            }}
-          >
-            <CalendarIcon className="w-4 h-4" />
-            {t('hospital.viewSchedule')}
-          </Link>
-        </div>
+          <CalendarIcon className="w-4 h-4" />
+          {t('hospital.viewSchedule')}
+        </Link>
       </div>
 
       {/* Overview Stats*/}
@@ -142,16 +146,20 @@ export default function HospitalDoctorDashboardPage() {
           return (
             <div
               key={card.label}
-              className="rounded-2xl border p-5 bg-white shadow-sm flex items-center justify-between transition-all duration-300 hover:shadow-md"
+              className="rounded-2xl border p-5 bg-white shadow-sm flex flex-col items-center text-center transition-all duration-300 hover:shadow-md"
               style={{ borderColor: card.borderColor }}
             >
-              <div>
-                <p className="text-sm font-medium text-gray-500">{card.label}</p>
-                <h3 className="mt-2 text-2xl font-bold text-gray-900">{card.title}</h3>
+              <div className="rounded-xl p-2.5 mb-2" style={{ backgroundColor: card.iconBg }}>
+                <Icon className="w-5 h-5" style={{ color: card.iconColor }} />
               </div>
-              <div className="rounded-xl p-3" style={{ backgroundColor: card.iconBg }}>
-                <Icon className="w-6 h-6" style={{ color: card.iconColor }} />
-              </div>
+              <p className="text-[11px] font-bold uppercase tracking-wider" style={{ color: card.labelColor }}>{card.label}</p>
+              <h3 className="mt-2 text-3xl font-bold text-gray-900">{card.title}</h3>
+              <span
+                className="mt-3 inline-block px-3 py-1 rounded-full text-[10px] font-semibold"
+                style={{ background: card.pillBg, color: card.pillColor }}
+              >
+                {card.trend}
+              </span>
             </div>
           );
         })}
@@ -162,7 +170,7 @@ export default function HospitalDoctorDashboardPage() {
         {/*Weekly Patient Visits */}
         <div className="lg:col-span-6 bg-white rounded-2xl border border-gray-100 p-6 shadow-sm flex flex-col justify-between">
           <div className="text-center mb-6">
-            <h3 className="text-xs font-bold tracking-wider uppercase text-slate-700">
+            <h3 className="text-xs font-bold tracking-wider uppercase text-blue-600">
               {t('hospital.weeklyPatientVisitsRates')}
             </h3>
           </div>
@@ -252,38 +260,25 @@ export default function HospitalDoctorDashboardPage() {
       {/* Patient Categories and Notifications */}
       <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
         <div className="xl:col-span-4 bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
-          <div className="text-xs font-bold tracking-wider uppercase text-slate-700 mb-4">
+          <div className="text-center text-xs font-bold tracking-wider uppercase text-blue-600 mb-4">
             {t('hospital.patientCategories')}
           </div>
           <div className="flex justify-center">
             <div className="relative w-64 h-64 rounded-full" style={{ background: categoryGradient }}>
-              <div className="absolute inset-0 m-10 rounded-full bg-white flex flex-col items-center justify-center">
-                <span className="text-sm font-semibold text-gray-500">{t('hospital.totalPatients')}</span>
-                <span className="text-3xl font-bold text-slate-900">{patientCategoryTotal}</span>
-              </div>
+              <div className="absolute inset-0 m-10 rounded-full bg-white" />
             </div>
           </div>
-          <div className="mt-6 grid grid-cols-2 gap-3">
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
             {MOCK_PATIENT_CATEGORIES.map((category) => (
-              <div key={category.label} className="rounded-2xl bg-slate-50 p-3 flex items-center gap-3">
-                <span className="w-3 h-3 rounded-full" style={{ backgroundColor: category.color }} />
-                <div>
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">{category.label}</div>
-                  <div className="text-sm font-bold text-gray-900">{category.value}</div>
-                </div>
+              <div key={category.label} className="flex items-center gap-2">
+                <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: category.color }} />
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">{category.label}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="xl:col-span-8 bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
-          <div className="flex items-center justify-between mb-6">
-            <div>
-              <h2 className="text-xl font-bold text-slate-900">{t('hospital.notification')}</h2>
-              <p className="text-xs text-gray-400 mt-0.5">Latest hospital alerts and priorities</p>
-            </div>
-          </div>
-
           <div className="overflow-x-auto">
             <table className="w-full text-left border-collapse">
               <thead>

--- a/src/app/hospital/doctor/inventory/page.tsx
+++ b/src/app/hospital/doctor/inventory/page.tsx
@@ -3,7 +3,7 @@ export default function HospitalDoctorInventoryPage() {
     <div className="space-y-6">
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
         <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Inventory</h1>
-        <p className="mt-1 text-gray-500 text-sm">E-Vuze Healthcare Platform</p>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>E-Vuze Healthcare Platform</p>
       </div>
     </div>
   );

--- a/src/app/hospital/doctor/messages/page.tsx
+++ b/src/app/hospital/doctor/messages/page.tsx
@@ -14,10 +14,21 @@ import { Conversation, Message } from '@/types/hospital';
 export default function DoctorMessagesPage() {
     const { t } = useTranslation();
     const [conversations, setConversations] = useState<Conversation[]>(MOCK_CONVERSATIONS);
-    const [activeId, setActiveId] = useState<string>(MOCK_CONVERSATIONS[0].id);
+    const [activeId, setActiveId] = useState<string | null>(null);
     const [inputText, setInputText] = useState('');
+    const [search, setSearch] = useState('');
 
-    const activeConversation = conversations.find(c => c.id === activeId) || conversations[0];
+    const activeConversation = conversations.find(c => c.id === activeId) ?? null;
+
+    const filteredConversations = conversations.filter(c => {
+        const q = search.trim().toLowerCase();
+        if (!q) return true;
+        return (
+            c.senderName.toLowerCase().includes(q) ||
+            c.lastMessage.toLowerCase().includes(q) ||
+            (c.role?.toLowerCase().includes(q) ?? false)
+        );
+    });
     const messagesEndRef = useRef<HTMLDivElement>(null);
 
     // Auto-scroll to bottom of messages
@@ -27,7 +38,7 @@ export default function DoctorMessagesPage() {
 
     useEffect(() => {
         scrollToBottom();
-    }, [activeConversation.messages]);
+    }, [activeConversation?.messages]);
 
     const handleSendMessage = (e?: React.FormEvent) => {
         if (e) e.preventDefault();
@@ -58,20 +69,13 @@ export default function DoctorMessagesPage() {
     return (
         <div className="max-w-7xl mx-auto p-4 lg:p-8 h-[calc(100vh-140px)] flex flex-col gap-6">
             {/* ── Page Hero ── */}
-            <div
-                className="relative rounded-3xl overflow-hidden px-8 py-10 bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-100 shadow-sm shrink-0"
-            >
-                <div className="relative z-10">
-                    <h1 className="text-3xl font-extrabold text-blue-900 tracking-tight">
-                        {t('hospital.messages') || 'Doctor Messaging Hub'}
-                    </h1>
-                    <p className="text-blue-600/80 mt-1 text-base font-medium">
-                        Communicate directly with patients, pharmacists, and medical staff in real-time.
-                    </p>
-                </div>
-                <div className="absolute top-1/2 -right-6 -translate-y-1/2 opacity-5">
-                    <ChatBubbleLeftRightIcon className="w-48 h-48 text-blue-600" />
-                </div>
+            <div className="rounded-2xl px-8 py-8 shrink-0" style={{ background: '#EBF5FF' }}>
+                <h1 className="text-3xl font-bold tracking-tight" style={{ color: '#1E3A5F' }}>
+                    {t('hospital.messages') || 'Doctor Messaging Hub'}
+                </h1>
+                <p className="mt-1 text-sm font-medium" style={{ color: '#3B82F6' }}>
+                    Communicate directly with patients, pharmacists, and medical staff in real-time.
+                </p>
             </div>
 
             <div className="flex-1 flex gap-6 overflow-hidden min-h-0">
@@ -82,6 +86,8 @@ export default function DoctorMessagesPage() {
                             <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                             <input
                                 type="text"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
                                 placeholder="Search conversations..."
                                 className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all"
                             />
@@ -89,40 +95,42 @@ export default function DoctorMessagesPage() {
                     </div>
 
                     <div className="flex-1 overflow-y-auto">
+                        {filteredConversations.length === 0 ? (
+                            <p className="text-sm text-gray-400 text-center py-8">No conversations found</p>
+                        ) : (
                         <ul className="divide-y divide-gray-50">
-                            {conversations.map((conv) => (
+                            {filteredConversations.map((conv) => (
                                 <li
                                     key={conv.id}
                                     onClick={() => setActiveId(conv.id)}
-                                    className={`p-4 cursor-pointer transition-all hover:bg-gray-50 group border-l-4 ${activeId === conv.id ? 'bg-blue-50/80 border-blue-600' : 'border-transparent'
+                                    className={`px-5 py-4 cursor-pointer transition-all hover:bg-gray-50 ${activeId === conv.id ? 'bg-blue-50/80' : ''
                                         }`}
                                 >
-                                    <div className="flex items-start gap-4">
-                                        <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-100 flex items-center justify-center text-blue-700 font-bold text-lg shadow-inner shrink-0 group-hover:scale-105 transition-transform">
-                                            {conv.initials}
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <h3 className="text-sm font-bold text-gray-900 truncate">{conv.senderName}</h3>
+                                            <p className="text-xs text-gray-500 truncate mt-1">{conv.lastMessage}</p>
                                         </div>
-                                        <div className="flex-1 min-w-0">
-                                            <div className="flex justify-between items-center mb-0.5">
-                                                <h3 className="text-sm font-bold text-gray-900 truncate">{conv.senderName}</h3>
-                                                <span className="text-[10px] font-medium text-gray-400">{conv.timestamp}</span>
-                                            </div>
-                                            <p className="text-xs font-semibold text-blue-600 mb-1">{conv.role}</p>
-                                            <p className="text-xs text-gray-500 truncate">{conv.lastMessage}</p>
+                                        <div className="flex flex-col items-end gap-1.5 shrink-0">
+                                            <span className="text-[10px] font-medium text-gray-400">
+                                                {new Date(conv.timestamp).toLocaleDateString([], { month: 'short', day: 'numeric' })}
+                                            </span>
+                                            {(conv.unreadCount ?? 0) > 0 && (
+                                                <span className="w-2 h-2 rounded-full bg-blue-600" />
+                                            )}
                                         </div>
-                                        {(conv.unreadCount ?? 0) > 0 && (
-                                            <div className="w-5 h-5 rounded-full bg-blue-600 text-white text-[10px] flex items-center justify-center font-bold">
-                                                {conv.unreadCount}
-                                            </div>
-                                        )}
                                     </div>
                                 </li>
                             ))}
                         </ul>
+                        )}
                     </div>
                 </div>
 
                 {/* ── Right Panel: Message Thread ── */}
                 <div className="flex-1 bg-white rounded-3xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
+                  {activeConversation ? (
+                   <>
                     {/* Header */}
                     <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
                         <div className="flex items-center gap-4">
@@ -189,6 +197,19 @@ export default function DoctorMessagesPage() {
                             </button>
                         </form>
                     </div>
+                   </>
+                  ) : (
+                    /* Empty state — no conversation selected */
+                    <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
+                        <div className="w-20 h-20 rounded-full flex items-center justify-center mb-5" style={{ background: '#EBF5FF' }}>
+                            <ChatBubbleLeftRightIcon className="w-9 h-9" style={{ color: '#38BDF8' }} />
+                        </div>
+                        <h3 className="text-xl font-bold text-gray-900">Your Messages</h3>
+                        <p className="text-sm text-gray-500 mt-2 max-w-xs leading-relaxed">
+                            Select a patient or pharmacy thread from the list on the left to view the message history and start chatting.
+                        </p>
+                    </div>
+                  )}
                 </div>
             </div>
         </div>

--- a/src/app/hospital/doctor/messages/page.tsx
+++ b/src/app/hospital/doctor/messages/page.tsx
@@ -73,7 +73,7 @@ export default function DoctorMessagesPage() {
                 <h1 className="text-3xl font-bold tracking-tight" style={{ color: '#1E3A5F' }}>
                     {t('hospital.messages') || 'Doctor Messaging Hub'}
                 </h1>
-                <p className="mt-1 text-sm font-medium" style={{ color: '#3B82F6' }}>
+                <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>
                     Communicate directly with patients, pharmacists, and medical staff in real-time.
                 </p>
             </div>

--- a/src/app/hospital/doctor/patient/page.tsx
+++ b/src/app/hospital/doctor/patient/page.tsx
@@ -26,6 +26,7 @@ export default function HospitalDoctorPatientsPage() {
   const [search, setSearch]             = useState('');
   const [statusFilter, setStatus]       = useState<PatientStatus | 'ALL'>('ALL');
   const [conditionFilter, setCondition] = useState('ALL');
+  const [lastVisitFilter, setLastVisit] = useState('ALL');
   const [page, setPage]                 = useState(1);
 
   const total       = MOCK_PATIENTS.length;
@@ -38,6 +39,13 @@ export default function HospitalDoctorPatientsPage() {
   const filtered = MOCK_PATIENTS
     .filter(p => statusFilter === 'ALL' || p.status === statusFilter)
     .filter(p => conditionFilter === 'ALL' || p.condition === conditionFilter)
+    .filter(p => {
+      if (lastVisitFilter === 'ALL') return true;
+      const visit = new Date(p.lastVisit).getTime();
+      if (Number.isNaN(visit)) return true;
+      const days = (Date.now() - visit) / 86_400_000;
+      return days <= Number(lastVisitFilter);
+    })
     .filter(p =>
       p.name.toLowerCase().includes(search.toLowerCase()) ||
       p.patientId.toLowerCase().includes(search.toLowerCase())
@@ -67,51 +75,62 @@ export default function HospitalDoctorPatientsPage() {
         <StatCard label="Total Patients"  value={total}       icon={<UserGroupIcon className="w-6 h-6" />} color="blue"   trend="+12% from last week"  />
         <StatCard label="Active Cases"    value={activeCount} icon={<ActiveCasesIcon />}                   color="green"  trend="+12% from last month" />
         <StatCard label="New Patients"    value={newCount}    icon={<UserPlusIcon className="w-6 h-6" />}  color="orange" trend="+5% from last week"   />
-        <StatCard label="Follow Ups Due"  value={followUps}   icon={<CalendarDaysIcon className="w-6 h-6" />} color="purple" trend="-12% from last week" />
+        <StatCard label="Follow ups due"  value={followUps}   icon={<CalendarDaysIcon className="w-6 h-6" />} color="purple" trend="-12% from last week" />
       </div>
 
-      {/* Filters + table card */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100">
-        {/* Filter bar */}
-        <div className="flex flex-wrap items-center gap-3 px-6 py-4 border-b border-gray-100">
-          <div className="relative flex-1 min-w-[200px] max-w-xs">
-            <MagnifyingGlassIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-            <input
-              type="text"
-              placeholder="Search name by ID,..."
-              value={search}
-              onChange={e => applyFilter(() => setSearch(e.target.value))}
-              className="pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            />
-          </div>
-
-          <select
-            value={statusFilter}
-            onChange={e => applyFilter(() => setStatus(e.target.value as PatientStatus | 'ALL'))}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
-          >
-            <option value="ALL">All Status</option>
-            <option value="ACTIVE">Active</option>
-            <option value="CRITICAL">Critical</option>
-            <option value="INACTIVE">Inactive</option>
-          </select>
-
-          <select
-            value={conditionFilter}
-            onChange={e => applyFilter(() => setCondition(e.target.value))}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
-          >
-            {conditions.map(c => (
-              <option key={c} value={c}>{c === 'ALL' ? 'All Conditions' : c}</option>
-            ))}
-          </select>
-
-          <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors">
-            <FunnelIcon className="w-4 h-4" />
-            Filter
-          </button>
+      {/* Filter bar — standalone card */}
+      <div className="flex flex-wrap items-center gap-3 bg-white rounded-xl shadow-sm border border-gray-100 px-4 py-3">
+        <div className="relative flex-1 min-w-[200px] max-w-xs">
+          <MagnifyingGlassIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search name by ID,..."
+            value={search}
+            onChange={e => applyFilter(() => setSearch(e.target.value))}
+            className="pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
         </div>
 
+        <select
+          value={statusFilter}
+          onChange={e => applyFilter(() => setStatus(e.target.value as PatientStatus | 'ALL'))}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+        >
+          <option value="ALL">All Status</option>
+          <option value="ACTIVE">Active</option>
+          <option value="CRITICAL">Critical</option>
+          <option value="INACTIVE">Inactive</option>
+        </select>
+
+        <select
+          value={conditionFilter}
+          onChange={e => applyFilter(() => setCondition(e.target.value))}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+        >
+          {conditions.map(c => (
+            <option key={c} value={c}>{c === 'ALL' ? 'All Conditions' : c}</option>
+          ))}
+        </select>
+
+        <select
+          value={lastVisitFilter}
+          onChange={e => applyFilter(() => setLastVisit(e.target.value))}
+          className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+        >
+          <option value="ALL">Last Visit</option>
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="90">Last 90 days</option>
+        </select>
+
+        <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors">
+          <FunnelIcon className="w-4 h-4" />
+          Filter
+        </button>
+      </div>
+
+      {/* Table card */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100">
         {/* Table */}
         <div className="overflow-x-auto">
           <table className="w-full">

--- a/src/app/hospital/doctor/patient/page.tsx
+++ b/src/app/hospital/doctor/patient/page.tsx
@@ -28,6 +28,7 @@ export default function HospitalDoctorPatientsPage() {
   const [conditionFilter, setCondition] = useState('ALL');
   const [lastVisitFilter, setLastVisit] = useState('ALL');
   const [page, setPage]                 = useState(1);
+  const [now]                           = useState(() => Date.now());
 
   const total       = MOCK_PATIENTS.length;
   const activeCount = MOCK_PATIENTS.filter(p => p.status === 'ACTIVE').length;
@@ -43,7 +44,7 @@ export default function HospitalDoctorPatientsPage() {
       if (lastVisitFilter === 'ALL') return true;
       const visit = new Date(p.lastVisit).getTime();
       if (Number.isNaN(visit)) return true;
-      const days = (Date.now() - visit) / 86_400_000;
+      const days = (now - visit) / 86_400_000;
       return days <= Number(lastVisitFilter);
     })
     .filter(p =>

--- a/src/app/hospital/doctor/patient/page.tsx
+++ b/src/app/hospital/doctor/patient/page.tsx
@@ -65,7 +65,7 @@ export default function HospitalDoctorPatientsPage() {
       {/* Hero */}
       <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
         <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Patients</h1>
-        <p className="mt-1 text-sm" style={{ color: '#3B82F6' }}>
+        <p className="mt-1 text-sm" style={{ color: '#0284C7' }}>
           Manage and review assigned patients
         </p>
       </div>

--- a/src/app/hospital/doctor/prescription/page.tsx
+++ b/src/app/hospital/doctor/prescription/page.tsx
@@ -101,8 +101,8 @@ function TogglePill({ label, active, onClick }: { label: string; active: boolean
       className="px-4 py-1.5 rounded-full text-xs font-semibold transition-all border"
       style={
         active
-          ? { background: '#3B82F6', color: '#fff', borderColor: '#3B82F6' }
-          : { background: '#fff', color: '#6B7280', borderColor: '#E5E7EB' }
+          ? { background: '#DBEAFE', color: '#2563EB', borderColor: '#DBEAFE' }
+          : { background: '#F3F4F6', color: '#6B7280', borderColor: '#F3F4F6' }
       }
     >
       {label}
@@ -284,16 +284,22 @@ export default function HospitalDoctorPrescriptionPage() {
               <button
                 key={p.id}
                 onClick={() => { setSelected(p.id); setTab('prescriptions'); }}
-                className="w-full text-left px-3 py-2.5 rounded-xl transition-all"
+                className="w-full text-left px-3 py-2.5 rounded-xl transition-all flex items-center gap-2.5"
                 style={isActive ? { background: '#3B82F6', color: '#fff' } : { color: NAVY }}
               >
-                <p className="text-xs font-semibold leading-tight">{p.name}</p>
-                <p
-                  className="text-xs mt-0.5 leading-tight truncate"
-                  style={{ color: isActive ? 'rgba(255,255,255,0.75)' : '#9CA3AF' }}
-                >
-                  {p.condition.charAt(0) + p.condition.slice(1).toLowerCase()}
-                </p>
+                <span
+                  className="w-7 h-7 rounded-full shrink-0"
+                  style={{ background: isActive ? 'rgba(255,255,255,0.4)' : '#E5E7EB' }}
+                />
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold leading-tight truncate">{p.name}</p>
+                  <p
+                    className="text-xs mt-0.5 leading-tight truncate"
+                    style={{ color: isActive ? 'rgba(255,255,255,0.75)' : '#9CA3AF' }}
+                  >
+                    {p.condition.charAt(0) + p.condition.slice(1).toLowerCase()}
+                  </p>
+                </div>
               </button>
             );
           })}
@@ -323,21 +329,22 @@ export default function HospitalDoctorPrescriptionPage() {
           </div>
         </div>
 
-        {/* Tabs */}
-        <div className="flex border-b border-gray-100 px-6">
-          {TABS.map(tab => (
-            <button
-              key={tab.id}
-              onClick={() => setTab(tab.id)}
-              className="relative px-4 py-3 text-xs font-semibold transition-colors"
-              style={{ color: activeTab === tab.id ? '#1D4ED8' : '#9CA3AF' }}
-            >
-              {tab.label}
-              {activeTab === tab.id && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full" style={{ background: '#1D4ED8' }} />
-              )}
-            </button>
-          ))}
+        {/* Tabs — segmented control */}
+        <div className="px-6 py-3 border-b border-gray-100">
+          <div className="flex items-center bg-gray-100 rounded-xl p-1">
+            {TABS.map(tab => (
+              <button
+                key={tab.id}
+                onClick={() => setTab(tab.id)}
+                className={`flex-1 px-4 py-2 text-xs font-semibold rounded-lg transition-all ${
+                  activeTab === tab.id ? 'bg-white shadow-sm' : ''
+                }`}
+                style={{ color: activeTab === tab.id ? '#1D4ED8' : '#6B7280' }}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Tab content */}
@@ -349,7 +356,7 @@ export default function HospitalDoctorPrescriptionPage() {
               No data available for this tab yet.
             </div>
           ) : (
-            <div className="flex gap-5 h-full">
+            <div className="flex gap-5 items-start">
 
               {/* ── Prescription form ── */}
               <div className="flex-1 min-w-0 bg-gray-50 rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
@@ -403,8 +410,8 @@ export default function HospitalDoctorPrescriptionPage() {
                             className="w-9 h-9 rounded-lg text-xs font-semibold transition-all border"
                             style={
                               active
-                                ? { background: '#3B82F6', color: '#fff', borderColor: '#3B82F6' }
-                                : { background: '#fff', color: '#6B7280', borderColor: '#E5E7EB' }
+                                ? { background: '#DBEAFE', color: '#2563EB', borderColor: '#DBEAFE' }
+                                : { background: '#F3F4F6', color: '#6B7280', borderColor: '#F3F4F6' }
                             }
                           >
                             {day}
@@ -443,7 +450,7 @@ export default function HospitalDoctorPrescriptionPage() {
               </div>
 
               {/* ── Current prescriptions ── */}
-              <div className="w-64 shrink-0 flex flex-col gap-3 overflow-y-auto">
+              <div className="w-64 shrink-0 flex flex-col gap-3">
                 {rxList.length === 0 ? (
                   <div className="flex items-center justify-center h-24 text-xs text-gray-400 bg-gray-50 rounded-2xl border border-gray-100">
                     No prescriptions yet.

--- a/src/app/hospital/doctor/prescription/page.tsx
+++ b/src/app/hospital/doctor/prescription/page.tsx
@@ -443,7 +443,7 @@ export default function HospitalDoctorPrescriptionPage() {
 
                 <button
                   className="mt-auto w-full py-2.5 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
-                  style={{ background: '#3B82F6' }}
+                  style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}
                 >
                   Add Medicine
                 </button>

--- a/src/app/hospital/doctor/schedule/page.tsx
+++ b/src/app/hospital/doctor/schedule/page.tsx
@@ -133,7 +133,7 @@ export default function DoctorSchedulePage() {
                 <h1 className="text-3xl sm:text-4xl font-bold tracking-tight" style={{ color: '#1E3A5F' }}>
                     {t('hospital.schedule') || 'Doctor Schedule & Calendar'}
                 </h1>
-                <p className="mt-2 text-sm sm:text-base font-medium" style={{ color: '#3B82F6' }}>
+                <p className="mt-2 text-sm sm:text-base font-medium" style={{ color: '#0284C7' }}>
                     Organize, view, and reserve time slots for examinations, surgeries, and clinics.
                 </p>
             </div>
@@ -175,7 +175,7 @@ export default function DoctorSchedulePage() {
                         </button>
                     </div>
 
-                    <button className="flex items-center gap-2 bg-sky-500 hover:bg-sky-600 text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-sm transition-all">
+                    <button className="flex items-center gap-2 text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-sm transition-all hover:opacity-90" style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}>
                         <PlusIcon className="w-4 h-4" />
                         Reserve Time Slot
                     </button>

--- a/src/app/hospital/doctor/schedule/page.tsx
+++ b/src/app/hospital/doctor/schedule/page.tsx
@@ -4,19 +4,32 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     startOfWeek,
-    addDays,
-    addWeeks,
-    subWeeks,
-    format,
+    endOfWeek,
     startOfMonth,
     endOfMonth,
     eachDayOfInterval,
+    addDays,
+    addWeeks,
+    subWeeks,
+    addMonths,
+    subMonths,
+    isSameMonth,
     isSameDay,
-    isToday
+    format,
+    isToday,
 } from 'date-fns';
-import { ChevronLeftIcon, ChevronRightIcon, CalendarIcon, PlusIcon } from '@heroicons/react/24/outline';
+import {
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    ChevronUpIcon,
+    PlusIcon,
+    VideoCameraIcon,
+    UserIcon,
+    UsersIcon,
+    EllipsisHorizontalIcon,
+} from '@heroicons/react/24/outline';
 import { MOCK_SCHEDULE } from '@/mock/hospital/schedule';
-import { ScheduleEntry, EntryColor } from '@/types/hospital';
+import { EntryColor } from '@/types/hospital';
 
 const COLOR_MAP: Record<EntryColor, string> = {
     blue: 'bg-blue-50 text-blue-700 border-blue-200',
@@ -26,94 +39,138 @@ const COLOR_MAP: Record<EntryColor, string> = {
     red: 'bg-red-50 text-red-700 border-red-200',
 };
 
+// Working hours shown on both views (8 AM – 4 PM)
+const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+function hourLabel(h: number) {
+    const period = h < 12 ? 'AM' : 'PM';
+    const display = h % 12 === 0 ? 12 : h % 12;
+    return `${String(display).padStart(2, '0')}:00 ${period}`;
+}
+
+function startHour(entry: { startTime?: string }) {
+    return entry.startTime ? parseInt(entry.startTime.split(':')[0], 10) : -1;
+}
+
+// ── Mini month calendar used in the calendar-view sidebar ──────────────────────
+function MiniCalendar({ selected, onSelect }: { selected: Date; onSelect: (d: Date) => void }) {
+    const [month, setMonth] = useState(selected);
+    const gridStart = startOfWeek(startOfMonth(month), { weekStartsOn: 0 });
+    const gridEnd = endOfWeek(endOfMonth(month), { weekStartsOn: 0 });
+    const days = eachDayOfInterval({ start: gridStart, end: gridEnd });
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-bold text-gray-700">{format(month, 'MMMM yyyy')}</span>
+                <div className="flex items-center gap-1">
+                    <button onClick={() => setMonth(subMonths(month, 1))} className="p-1 rounded hover:bg-gray-100">
+                        <ChevronLeftIcon className="w-3.5 h-3.5 text-gray-400" />
+                    </button>
+                    <button onClick={() => setMonth(addMonths(month, 1))} className="p-1 rounded hover:bg-gray-100">
+                        <ChevronRightIcon className="w-3.5 h-3.5 text-gray-400" />
+                    </button>
+                </div>
+            </div>
+            <div className="grid grid-cols-7 text-center text-[10px] font-semibold text-gray-400 mb-1">
+                {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => <span key={i}>{d}</span>)}
+            </div>
+            <div className="grid grid-cols-7 gap-y-1 text-center text-[11px]">
+                {days.map((day) => {
+                    const muted = !isSameMonth(day, month);
+                    const sel = isSameDay(day, selected);
+                    const today = isToday(day);
+                    return (
+                        <button
+                            key={day.toISOString()}
+                            onClick={() => onSelect(day)}
+                            className={`w-6 h-6 mx-auto rounded-full flex items-center justify-center transition-colors ${
+                                sel
+                                    ? 'bg-blue-600 text-white font-bold'
+                                    : today
+                                        ? 'text-blue-600 font-bold'
+                                        : muted
+                                            ? 'text-gray-300'
+                                            : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            {format(day, 'd')}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
 export default function DoctorSchedulePage() {
     const { t } = useTranslation();
-    const [currentDate, setCurrentDate] = useState(new Date('2026-06-01')); // Setting to June 1st to match mock data week
-    const [viewMode, setViewMode] = useState<'WEEK' | 'MONTH'>('WEEK');
+    const [currentDate, setCurrentDate] = useState(new Date('2026-06-01')); // matches mock week
+    const [view, setView] = useState<'LIST' | 'CALENDAR'>('LIST');
 
     const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 }); // Monday
     const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 
-    const monthStart = startOfMonth(currentDate);
-    const monthEnd = endOfMonth(currentDate);
-    const monthDays = eachDayOfInterval({ start: monthStart, end: monthEnd });
+    const goPrev = () =>
+        view === 'LIST' ? setCurrentDate(addDays(currentDate, -1)) : setCurrentDate(subWeeks(currentDate, 1));
+    const goNext = () =>
+        view === 'LIST' ? setCurrentDate(addDays(currentDate, 1)) : setCurrentDate(addWeeks(currentDate, 1));
 
-    const handlePrev = () => {
-        if (viewMode === 'WEEK') setCurrentDate(subWeeks(currentDate, 1));
-        else setCurrentDate(addDays(monthStart, -1));
-    };
+    const dayKey = (d: Date) => format(d, 'yyyy-MM-dd');
+    const entriesForDay = (d: Date) => MOCK_SCHEDULE.filter((e) => e.date === dayKey(d));
+    const entryAt = (d: Date, hour: number) =>
+        MOCK_SCHEDULE.find((e) => e.date === dayKey(d) && startHour(e) === hour);
 
-    const handleNext = () => {
-        if (viewMode === 'WEEK') setCurrentDate(addWeeks(currentDate, 1));
-        else setCurrentDate(addDays(monthEnd, 1));
-    };
-
-    const getEntriesForDay = (day: Date) => {
-        return MOCK_SCHEDULE.filter(entry =>
-            format(new Date(entry.date), 'yyyy-MM-dd') === format(day, 'yyyy-MM-dd')
-        );
-    };
+    const typeMeta = (type?: string) =>
+        type === 'ONLINE'
+            ? { label: 'Video Call', Icon: VideoCameraIcon }
+            : { label: 'In-Person', Icon: UserIcon };
 
     return (
         <div className="max-w-7xl mx-auto p-4 lg:p-8 space-y-6">
             {/* ── Page Hero ── */}
-            <div
-                className="relative rounded-3xl overflow-hidden px-8 py-12 bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-100/50 shadow-sm"
-            >
-                <div className="relative z-10">
-                    <h1 className="text-4xl font-extrabold text-blue-900 tracking-tight">
-                        {t('hospital.schedule') || 'Doctor Schedule & Calendar'}
-                    </h1>
-                    <p className="text-blue-600/80 mt-2 text-lg font-medium">
-                        Organize, view, and reserve time slots for examinations, surgeries, and clinics.
-                    </p>
-                </div>
-                <div className="absolute top-1/2 -right-8 -translate-y-1/2 opacity-10">
-                    <CalendarIcon className="w-64 h-64 text-blue-600" />
-                </div>
+            <div className="rounded-2xl px-8 py-8" style={{ background: '#EBF5FF' }}>
+                <h1 className="text-3xl sm:text-4xl font-bold tracking-tight" style={{ color: '#1E3A5F' }}>
+                    {t('hospital.schedule') || 'Doctor Schedule & Calendar'}
+                </h1>
+                <p className="mt-2 text-sm sm:text-base font-medium" style={{ color: '#3B82F6' }}>
+                    Organize, view, and reserve time slots for examinations, surgeries, and clinics.
+                </p>
             </div>
 
             {/* ── Controls ── */}
-            <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-white p-4 rounded-2xl shadow-sm border border-gray-100">
-                <div className="flex items-center gap-2 bg-gray-50 p-1 rounded-xl border border-gray-100">
+            <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+                {/* List / Calendar toggle */}
+                <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-xl">
                     <button
-                        onClick={() => setViewMode('WEEK')}
-                        className={`px-6 py-2 rounded-lg text-sm font-semibold transition-all ${viewMode === 'WEEK'
-                            ? 'bg-blue-600 text-white shadow-md'
-                            : 'text-gray-500 hover:text-gray-800'
-                            }`}
+                        onClick={() => setView('LIST')}
+                        className={`px-6 py-2 rounded-lg text-sm font-semibold transition-all ${
+                            view === 'LIST' ? 'bg-blue-600 text-white shadow-sm' : 'text-gray-500 hover:text-gray-800'
+                        }`}
                     >
-                        Weekly Overview
+                        Daily Schedule
                     </button>
                     <button
-                        onClick={() => setViewMode('MONTH')}
-                        className={`px-6 py-2 rounded-lg text-sm font-semibold transition-all ${viewMode === 'MONTH'
-                            ? 'bg-blue-600 text-white shadow-md'
-                            : 'text-gray-500 hover:text-gray-800'
-                            }`}
+                        onClick={() => setView('CALENDAR')}
+                        className={`px-6 py-2 rounded-lg text-sm font-semibold transition-all ${
+                            view === 'CALENDAR' ? 'bg-blue-600 text-white shadow-sm' : 'text-gray-500 hover:text-gray-800'
+                        }`}
                     >
-                        Monthly View
+                        Weekly Overview
                     </button>
                 </div>
 
                 <div className="flex items-center gap-4">
                     <div className="flex items-center gap-2">
-                        <button
-                            onClick={handlePrev}
-                            className="p-2 rounded-full hover:bg-gray-100 transition-colors border border-gray-200"
-                        >
+                        <button onClick={goPrev} className="p-2 rounded-full hover:bg-gray-100 transition-colors border border-gray-200">
                             <ChevronLeftIcon className="w-5 h-5 text-gray-600" />
                         </button>
-                        <span className="text-base font-bold text-gray-700 min-w-[140px] text-center">
-                            {viewMode === 'WEEK'
-                                ? `${format(weekDays[0], 'MMM d')} - ${format(weekDays[6], 'MMM d, yyyy')}`
-                                : format(currentDate, 'MMMM yyyy')
-                            }
+                        <span className="text-sm font-bold text-gray-700 min-w-[180px] text-center">
+                            {view === 'LIST'
+                                ? format(currentDate, 'EEEE, MMM d, yyyy')
+                                : `${format(weekDays[0], 'MMM d')} – ${format(weekDays[6], 'MMM d, yyyy')}`}
                         </span>
-                        <button
-                            onClick={handleNext}
-                            className="p-2 rounded-full hover:bg-gray-100 transition-colors border border-gray-200"
-                        >
+                        <button onClick={goNext} className="p-2 rounded-full hover:bg-gray-100 transition-colors border border-gray-200">
                             <ChevronRightIcon className="w-5 h-5 text-gray-600" />
                         </button>
                     </div>
@@ -125,114 +182,158 @@ export default function DoctorSchedulePage() {
                 </div>
             </div>
 
-            {/* ── Weekly View ── */}
-            {viewMode === 'WEEK' && (
-                <div className="grid grid-cols-7 gap-4">
-                    {weekDays.map((day, idx) => {
-                        const dayEntries = getEntriesForDay(day);
-                        const isTodayDay = isToday(day);
-
+            {/* ── List view ── */}
+            {view === 'LIST' && (
+                <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-3 sm:p-4 space-y-2">
+                    {HOURS.map((hour) => {
+                        const entry = entryAt(currentDate, hour);
+                        if (entry) {
+                            const accent = COLOR_MAP[entry.color] ?? COLOR_MAP.blue;
+                            return (
+                                <div
+                                    key={hour}
+                                    className="flex items-center gap-4 rounded-xl border border-gray-100 bg-white pl-0 pr-4 py-3 shadow-sm overflow-hidden"
+                                >
+                                    <span className="w-1.5 self-stretch rounded-full bg-blue-500 shrink-0" />
+                                    <span className="text-sm font-bold text-gray-700 w-20 shrink-0">{hourLabel(hour)}</span>
+                                    <span className="text-sm font-bold text-gray-900 flex-1 truncate">{entry.patientName}</span>
+                                    <span className={`text-[10px] font-bold uppercase tracking-wider px-3 py-1.5 rounded-full border ${accent}`}>
+                                        {typeMeta(entry.type).label}
+                                    </span>
+                                </div>
+                            );
+                        }
                         return (
-                            <div key={idx} className="flex flex-col gap-4">
-                                <div className={`text-center py-3 rounded-xl border transition-all ${isTodayDay
-                                    ? 'bg-blue-50 border-blue-200 shadow-sm'
-                                    : 'bg-white border-gray-100'
-                                    }`}>
-                                    <p className={`text-xs font-bold uppercase tracking-wider ${isTodayDay ? 'text-blue-600' : 'text-gray-400'}`}>
-                                        {format(day, 'EEE')}
-                                    </p>
-                                    <p className={`text-xl font-black mt-0.5 ${isTodayDay ? 'text-blue-700' : 'text-gray-800'}`}>
-                                        {format(day, 'd')}
-                                    </p>
-                                </div>
-
-                                <div className={`flex-1 min-h-[500px] rounded-2xl p-3 space-y-3 transition-colors ${isTodayDay ? 'bg-blue-50/30' : 'bg-gray-50/50'
-                                    }`}>
-                                    {dayEntries.length > 0 ? (
-                                        dayEntries.map((entry) => (
-                                            <div
-                                                key={entry.id}
-                                                className={`p-3 rounded-xl border shadow-sm transition-transform hover:scale-[1.02] cursor-pointer ${COLOR_MAP[entry.color]}`}
-                                            >
-                                                <p className="text-[10px] font-bold opacity-70 uppercase mb-1">{entry.time}</p>
-                                                <p className="text-sm font-bold leading-tight">{entry.patientName}</p>
-                                                {entry.type && (
-                                                    <p className="text-[10px] font-medium mt-1 truncate opacity-80">{entry.type}</p>
-                                                )}
-                                            </div>
-                                        ))
-                                    ) : (
-                                        <div className="flex flex-col items-center justify-center h-full opacity-20 py-10">
-                                            <CalendarIcon className="w-8 h-8 mb-2" />
-                                            <p className="text-xs font-medium">No shifts</p>
-                                        </div>
-                                    )}
-                                </div>
+                            <div
+                                key={hour}
+                                className="flex items-center gap-4 rounded-xl bg-gray-50/70 px-4 py-3"
+                            >
+                                <span className="text-sm font-bold text-gray-500 w-20 shrink-0">{hourLabel(hour)}</span>
+                                <span className="text-sm font-medium text-gray-400 flex-1">Available Time Slot</span>
+                                <button className="text-[11px] font-semibold text-gray-500 bg-gray-100 hover:bg-gray-200 px-3 py-1.5 rounded-full transition-colors flex items-center gap-1">
+                                    <PlusIcon className="w-3 h-3" />
+                                    Reserve
+                                </button>
                             </div>
                         );
                     })}
                 </div>
             )}
 
-            {/* ── Monthly View ── */}
-            {viewMode === 'MONTH' && (
-                <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
-                    <div className="grid grid-cols-7 bg-gray-50 border-b border-gray-100">
-                        {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(d => (
-                            <div key={d} className="py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">{d}</div>
-                        ))}
+            {/* ── Calendar (weekly time-grid) view ── */}
+            {view === 'CALENDAR' && (
+              <div className="flex flex-col lg:flex-row gap-6">
+                {/* Sidebar */}
+                <aside className="w-full lg:w-64 shrink-0 bg-white rounded-2xl border border-gray-100 shadow-sm p-4 space-y-5">
+                    <MiniCalendar selected={currentDate} onSelect={setCurrentDate} />
+
+                    {/* Search for people */}
+                    <div className="relative">
+                        <UsersIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                        <input
+                            type="text"
+                            placeholder="Search for people"
+                            className="w-full pl-9 pr-3 py-2 text-xs bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        />
                     </div>
-                    <div className="grid grid-cols-7">
-                        {/* Pad transition from previous month */}
-                        {Array.from({ length: (startOfWeek(monthStart, { weekStartsOn: 1 }).getDay() + 6) % 7 }).map((_, i) => (
-                            <div key={`pad-${i}`} className="h-32 border-b border-r border-gray-50 opacity-20" />
-                        ))}
 
-                        {monthDays.map((day, idx) => {
-                            const entries = getEntriesForDay(day);
-                            const isTodayDay = isToday(day);
+                    {/* Booking Pages */}
+                    <button className="w-full flex items-center justify-between text-sm font-semibold text-gray-700 hover:text-gray-900 transition-colors">
+                        <span>Booking Pages</span>
+                        <PlusIcon className="w-4 h-4 text-gray-400" />
+                    </button>
 
-                            return (
-                                <div
-                                    key={idx}
-                                    className={`h-32 p-3 border-b border-r border-gray-100 transition-colors relative group ${isTodayDay ? 'bg-blue-50/50' : 'hover:bg-gray-50/50'
-                                        }`}
-                                >
-                                    <span className={`text-sm font-bold ${isTodayDay ? 'text-blue-600 bg-blue-100 w-7 h-7 flex items-center justify-center rounded-full' : 'text-gray-700'
-                                        }`}>
-                                        {format(day, 'd')}
-                                    </span>
+                    {/* My calendars */}
+                    <div>
+                        <div className="flex items-center justify-between text-sm font-semibold text-gray-700 mb-2">
+                            <span>My calendars</span>
+                            <ChevronUpIcon className="w-4 h-4 text-gray-400" />
+                        </div>
+                        <div className="flex items-center gap-2 pl-1">
+                            <span className="w-3.5 h-3.5 rounded-sm shrink-0" style={{ background: '#22D3EE' }} />
+                            <span className="text-xs text-gray-600 flex-1 truncate">Dr. Charles Edwin</span>
+                            <EllipsisHorizontalIcon className="w-4 h-4 text-gray-300" />
+                        </div>
+                    </div>
 
-                                    {entries.length > 0 && (
-                                        <div className="mt-2 space-y-1">
-                                            <div className="flex items-center gap-1 bg-blue-600 text-white rounded-md px-2 py-1 shadow-sm">
-                                                <span className="text-[10px] font-bold">{entries.length}</span>
-                                                <span className="text-[10px] font-medium">Shifts</span>
-                                            </div>
-                                            <div className="flex -space-x-1.5 overflow-hidden">
-                                                {entries.slice(0, 3).map((e, i) => (
-                                                    <div
-                                                        key={e.id}
-                                                        className={`w-4 h-4 rounded-full border border-white shadow-sm ${e.color === 'blue' ? 'bg-blue-400' :
-                                                            e.color === 'green' ? 'bg-emerald-400' :
-                                                                e.color === 'orange' ? 'bg-orange-400' :
-                                                                    e.color === 'purple' ? 'bg-purple-400' : 'bg-red-400'
-                                                            }`}
-                                                    />
-                                                ))}
-                                                {entries.length > 3 && (
-                                                    <div className="w-4 h-4 rounded-full bg-gray-200 border border-white text-[8px] flex items-center justify-center font-bold text-gray-500">
-                                                        +{entries.length - 3}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    )}
+                    {/* Other calendars */}
+                    <div className="flex items-center justify-between text-sm font-semibold text-gray-700">
+                        <span>Other calendars</span>
+                        <div className="flex items-center gap-1">
+                            <PlusIcon className="w-4 h-4 text-gray-400" />
+                            <ChevronUpIcon className="w-4 h-4 text-gray-400" />
+                        </div>
+                    </div>
+                </aside>
+
+                {/* Week grid */}
+                <div className="flex-1 min-w-0 bg-white rounded-2xl border border-gray-100 shadow-sm overflow-x-auto">
+                    <div className="min-w-[640px]">
+                        {/* Day header row */}
+                        <div className="grid border-b border-gray-100" style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}>
+                            <div className="py-3" />
+                            {weekDays.map((day) => {
+                                const todayCol = isToday(day);
+                                return (
+                                    <div key={day.toISOString()} className="py-3 text-center border-l border-gray-100">
+                                        <p className={`text-[11px] font-bold uppercase tracking-wider ${todayCol ? 'text-blue-600' : 'text-gray-400'}`}>
+                                            {format(day, 'EEE')}
+                                        </p>
+                                        <p
+                                            className={`mt-1 text-sm font-bold inline-flex items-center justify-center w-7 h-7 rounded-full ${
+                                                todayCol ? 'bg-blue-600 text-white' : 'text-gray-700'
+                                            }`}
+                                        >
+                                            {format(day, 'd')}
+                                        </p>
+                                    </div>
+                                );
+                            })}
+                        </div>
+
+                        {/* Hour rows */}
+                        {HOURS.map((hour) => (
+                            <div
+                                key={hour}
+                                className="grid border-b border-gray-50 last:border-0"
+                                style={{ gridTemplateColumns: '64px repeat(7, 1fr)' }}
+                            >
+                                <div className="py-4 pr-2 text-right text-[11px] font-semibold text-gray-400">
+                                    {hourLabel(hour).replace(':00', '')}
                                 </div>
-                            );
-                        })}
+                                {weekDays.map((day) => {
+                                    const entry = entryAt(day, hour);
+                                    return (
+                                        <div key={day.toISOString()} className="min-h-[72px] border-l border-gray-100 p-1.5">
+                                            {entry && (() => {
+                                                const meta = typeMeta(entry.type);
+                                                const accent = COLOR_MAP[entry.color] ?? COLOR_MAP.blue;
+                                                return (
+                                                    <div className={`h-full rounded-lg border p-2 ${accent}`}>
+                                                        <p className="text-[10px] font-semibold opacity-80">
+                                                            {entry.startTime && format(new Date(`2026-01-01T${entry.startTime}`), 'h:mm a')}
+                                                        </p>
+                                                        <p className="text-xs font-bold leading-tight mt-0.5 truncate">{entry.patientName}</p>
+                                                        <p className="flex items-center gap-1 text-[10px] font-medium opacity-80 mt-1">
+                                                            <meta.Icon className="w-3 h-3" />
+                                                            {meta.label}
+                                                        </p>
+                                                    </div>
+                                                );
+                                            })()}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        ))}
                     </div>
                 </div>
+              </div>
+            )}
+
+            {/* Empty-day hint for list view */}
+            {view === 'LIST' && entriesForDay(currentDate).length === 0 && (
+                <p className="text-center text-xs text-gray-400">No reservations yet for this day — all slots are available.</p>
             )}
         </div>
     );

--- a/src/app/hospital/doctor/settings/page.tsx
+++ b/src/app/hospital/doctor/settings/page.tsx
@@ -61,7 +61,7 @@ export default function HospitalDoctorSettingsPage() {
       >
         <div>
           <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>Settings</h1>
-          <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+          <p className="mt-2 text-sm sm:text-base" style={{ color: '#0284C7' }}>
             Manage your account and preferences
           </p>
         </div>

--- a/src/app/hospital/nurse/dashboard/page.tsx
+++ b/src/app/hospital/nurse/dashboard/page.tsx
@@ -4,8 +4,14 @@
 
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
-import { CalendarIcon, UserGroupIcon, ChatBubbleLeftRightIcon, ClipboardDocumentListIcon, CalendarDaysIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { CalendarIcon, UserGroupIcon, ChatBubbleLeftRightIcon, ClipboardDocumentListIcon, CalendarDaysIcon, ArrowRightIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { nurseDashboardStats, nurseDashboardCardsData, nursePatients, nurseSchedule } from '@/mock/hospital/nurse';
+
+const ACTION_HREF: Record<string, string> = {
+  patients: '/hospital/nurse/patients',
+  tasks:    '/hospital/nurse/notes',
+  messages: '/hospital/nurse/messages',
+};
 
 export default function NurseDashboardPage() {
   const { t } = useTranslation();
@@ -91,12 +97,12 @@ export default function NurseDashboardPage() {
 
             <div className="flex-1" />
             <div className="border-t border-gray-200 my-4" />
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium" style={{ color: card.color }} >
+            <Link href={ACTION_HREF[card.key] ?? '#'} className="flex items-center justify-between group">
+              <span className="text-xs font-medium group-hover:underline" style={{ color: card.color }} >
                 {card.action}
               </span>
-              <ArrowRightIcon className="h-4 w-4" style={{ color: card.color }} />
-            </div>
+              <ArrowRightIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" style={{ color: card.color }} />
+            </Link>
           </div>
         );
       })}
@@ -170,7 +176,7 @@ export default function NurseDashboardPage() {
 
       {/* Schedule */}
       <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
-        <div className="flex items-center justify-between border-b px-5 py-4">
+        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
           <div className="flex items-center gap-2">
             <CalendarDaysIcon className="h-5 w-5 text-[#2563EB]" />
             <h2 className="font-semibold text-gray-800"> {t('hospital.todaySchedule')} </h2>
@@ -182,20 +188,22 @@ export default function NurseDashboardPage() {
         <div>
           {nurseSchedule.map((item) => (
             <div key={item.id}
-              className="flex items-center justify-between border-b px-5 py-4 last:border-b-0">
+              className="flex items-center justify-between border-b border-gray-100 px-5 py-4 last:border-b-0">
 
-              <div className="flex gap-5">
-                <span className="font-medium">{item.time}</span>
+              <div className="flex items-center gap-4">
+                <span className="text-sm text-gray-500 w-16 shrink-0">{item.time}</span>
+                <span className="w-2.5 h-2.5 rounded-full bg-blue-500 shrink-0" />
                 <div>
-                  <p className="font-medium">{item.title}</p>
-                  <p className="text-xs text-gray-500">{item.location}</p>
+                  <p className="text-sm font-semibold text-gray-800">{item.title}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{item.location}</p>
                 </div>
               </div>
 
               <span
-                className={`rounded-full px-3 py-1 text-xs font-medium ${
-                item.status === 'Completed' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700' }`}>
+                className={`inline-flex items-center gap-1 rounded-lg px-3 py-1 text-xs font-semibold ${
+                item.status === 'Completed' ? 'bg-green-100 text-green-700' : 'bg-blue-50 text-blue-600' }`}>
                 {item.status}
+                {item.status === 'Completed' && <CheckIcon className="w-3.5 h-3.5" strokeWidth={2.5} />}
               </span>
             </div>
           ))}

--- a/src/app/hospital/nurse/medications/page.tsx
+++ b/src/app/hospital/nurse/medications/page.tsx
@@ -52,7 +52,7 @@ export default function MedicationAdministrationPage() {
             <div className="bg-white rounded-3xl p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
                 <div className="relative z-10">
                     <h1 className="text-3xl font-bold text-[#1E3A5F]">Medication Administration</h1>
-                    <p className="text-[#64748B] mt-2 max-w-2xl font-medium">
+                    <p className="mt-2 max-w-2xl font-medium" style={{ color: '#0284C7' }}>
                         Track patient schedules, record doses, and monitor compliance in real-time.
                     </p>
                 </div>

--- a/src/app/hospital/nurse/medications/page.tsx
+++ b/src/app/hospital/nurse/medications/page.tsx
@@ -49,7 +49,7 @@ export default function MedicationAdministrationPage() {
     return (
         <div className="p-6 lg:p-8 space-y-8">
             {/* Header */}
-            <div className="bg-white rounded-3xl p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
+            <div className="rounded-3xl p-8 shadow-sm relative overflow-hidden" style={{ background: '#EBF5FF' }}>
                 <div className="relative z-10">
                     <h1 className="text-3xl font-bold text-[#1E3A5F]">Medication Administration</h1>
                     <p className="mt-2 max-w-2xl font-medium" style={{ color: '#0284C7' }}>

--- a/src/app/hospital/nurse/messages/page.tsx
+++ b/src/app/hospital/nurse/messages/page.tsx
@@ -78,7 +78,7 @@ export default function NurseMessagesPage() {
                     <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>
                         {t('hospital.messages') || 'Messages'}
                     </h1>
-                    <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+                    <p className="mt-2 text-sm sm:text-base" style={{ color: '#0284C7' }}>
                         Check your conversations with other nurses and doctors
                     </p>
                 </div>

--- a/src/app/hospital/nurse/notes/page.tsx
+++ b/src/app/hospital/nurse/notes/page.tsx
@@ -110,7 +110,7 @@ export default function NursingNotesPage() {
             <div className="bg-white rounded-3xl p-6 sm:p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
                 <div className="relative z-10">
                     <h1 className="text-2xl sm:text-3xl font-bold text-[#1E3A5F]">Nursing Notes & Documentation</h1>
-                    <p className="text-[#64748B] mt-2 max-w-2xl font-medium">
+                    <p className="mt-2 max-w-2xl font-medium" style={{ color: '#0284C7' }}>
                         Document patient observations, care activities, and treatment outcomes during your shift.
                     </p>
                 </div>

--- a/src/app/hospital/nurse/notes/page.tsx
+++ b/src/app/hospital/nurse/notes/page.tsx
@@ -107,7 +107,7 @@ export default function NursingNotesPage() {
     return (
         <div className="p-6 lg:p-8 space-y-8 bg-[#F8FAFC]">
             {/* Header */}
-            <div className="bg-white rounded-3xl p-6 sm:p-8 border border-[#E2E8F0] shadow-sm relative overflow-hidden">
+            <div className="rounded-3xl p-6 sm:p-8 shadow-sm relative overflow-hidden" style={{ background: '#EBF5FF' }}>
                 <div className="relative z-10">
                     <h1 className="text-2xl sm:text-3xl font-bold text-[#1E3A5F]">Nursing Notes & Documentation</h1>
                     <p className="mt-2 max-w-2xl font-medium" style={{ color: '#0284C7' }}>

--- a/src/app/hospital/nurse/patients/page.tsx
+++ b/src/app/hospital/nurse/patients/page.tsx
@@ -22,6 +22,7 @@ export default function NursePatientsPage() {
   const [conditionFilter, setCondition] = useState('ALL');
   const [lastVisitFilter, setLastVisit] = useState('ALL');
   const [page, setPage]                 = useState(1);
+  const [now]                           = useState(() => Date.now());
 
   const conditions = ['ALL', ...Array.from(new Set(MOCK_PATIENTS.map(p => p.condition)))];
 
@@ -32,7 +33,7 @@ export default function NursePatientsPage() {
       if (lastVisitFilter === 'ALL') return true;
       const visit = new Date(p.lastVisit).getTime();
       if (Number.isNaN(visit)) return true;
-      const days = (Date.now() - visit) / 86_400_000;
+      const days = (now - visit) / 86_400_000;
       return days <= Number(lastVisitFilter);
     })
     .filter(p =>

--- a/src/app/hospital/nurse/patients/page.tsx
+++ b/src/app/hospital/nurse/patients/page.tsx
@@ -1,3 +1,199 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Search, Filter, MoreVertical, ChevronLeft, ChevronRight,
+  Users, BedDouble, Activity, UserCheck,
+} from 'lucide-react';
+import { MOCK_PATIENTS } from '@/mock/hospital/consultations';
+import type { PatientStatus } from '@/types/hospital';
+
+const PAGE_SIZE = 3;
+
+const STATUS_BADGE: Record<PatientStatus, string> = {
+  ACTIVE:   'bg-green-100 text-green-700',
+  CRITICAL: 'bg-red-100   text-red-600',
+  INACTIVE: 'bg-gray-100  text-gray-600',
+};
+
 export default function NursePatientsPage() {
-  return <div />;
+  const [search, setSearch]             = useState('');
+  const [statusFilter, setStatus]       = useState<PatientStatus | 'ALL'>('ALL');
+  const [conditionFilter, setCondition] = useState('ALL');
+  const [lastVisitFilter, setLastVisit] = useState('ALL');
+  const [page, setPage]                 = useState(1);
+
+  const conditions = ['ALL', ...Array.from(new Set(MOCK_PATIENTS.map(p => p.condition)))];
+
+  const filtered = MOCK_PATIENTS
+    .filter(p => statusFilter === 'ALL' || p.status === statusFilter)
+    .filter(p => conditionFilter === 'ALL' || p.condition === conditionFilter)
+    .filter(p => {
+      if (lastVisitFilter === 'ALL') return true;
+      const visit = new Date(p.lastVisit).getTime();
+      if (Number.isNaN(visit)) return true;
+      const days = (Date.now() - visit) / 86_400_000;
+      return days <= Number(lastVisitFilter);
+    })
+    .filter(p =>
+      p.name.toLowerCase().includes(search.toLowerCase()) ||
+      p.patientId.toLowerCase().includes(search.toLowerCase())
+    );
+
+  const totalPages  = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage    = Math.min(page, totalPages);
+  const pageItems   = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  function applyFilter(fn: () => void) { fn(); setPage(1); }
+
+  return (
+    <div className="space-y-6">
+      {/* Hero */}
+      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Patients</h1>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Tracking Patients Information</p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard label="Total Patients"     value={50} icon={<Users className="w-6 h-6" />}     color="red"    sub="View all patients" />
+        <StatCard label="Admit Patients"     value={20} icon={<BedDouble className="w-6 h-6" />} color="purple" sub="Admitted" />
+        <StatCard label="Critical Patients"  value={15} icon={<Activity className="w-6 h-6" />}  color="blue"   sub="Immediate Care" />
+        <StatCard label="Discharged Patients" value={25} icon={<UserCheck className="w-6 h-6" />} color="green"  sub="Today" />
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3 bg-white rounded-xl shadow-sm border border-gray-100 px-4 py-3">
+        <div className="relative flex-1 min-w-[200px] max-w-xs">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search name by ID,..."
+            value={search}
+            onChange={e => applyFilter(() => setSearch(e.target.value))}
+            className="pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+        <select value={statusFilter} onChange={e => applyFilter(() => setStatus(e.target.value as PatientStatus | 'ALL'))} className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <option value="ALL">All Status</option>
+          <option value="ACTIVE">Active</option>
+          <option value="CRITICAL">Critical</option>
+          <option value="INACTIVE">Inactive</option>
+        </select>
+        <select value={conditionFilter} onChange={e => applyFilter(() => setCondition(e.target.value))} className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          {conditions.map(c => <option key={c} value={c}>{c === 'ALL' ? 'All Conditions' : c}</option>)}
+        </select>
+        <select value={lastVisitFilter} onChange={e => applyFilter(() => setLastVisit(e.target.value))} className="px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <option value="ALL">Last Visit</option>
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="90">Last 90 days</option>
+        </select>
+        <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors">
+          <Filter className="w-4 h-4" />
+          Filter
+        </button>
+      </div>
+
+      {/* Table card */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-gray-50">
+              <tr>
+                {['Patient', 'Patient ID', 'Age', 'Gender', 'Last visit', 'Condition', 'Status', ''].map((h, i) => (
+                  <th key={i} className="text-left px-6 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {pageItems.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-6 py-16 text-center">
+                    <p className="text-gray-500 font-medium">No patients found</p>
+                    <p className="text-gray-400 text-sm mt-1">Try adjusting your search or filters.</p>
+                  </td>
+                </tr>
+              ) : pageItems.map(p => (
+                <tr key={p.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-6 py-4 text-sm font-medium text-gray-900">{p.name}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{p.patientId}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{p.age}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{p.gender}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{p.lastVisit}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600 uppercase">{p.condition}</td>
+                  <td className="px-6 py-4">
+                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-full ${STATUS_BADGE[p.status]}`}>{p.status}</span>
+                  </td>
+                  <td className="px-6 py-4">
+                    <button className="text-gray-400 hover:text-gray-600 transition-colors"><MoreVertical className="w-5 h-5" /></button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {filtered.length > 0 && (
+          <div className="flex items-center justify-between px-6 py-4 border-t border-gray-100 text-sm text-gray-500">
+            <span>Showing {pageItems.length} of {filtered.length} patients</span>
+            <div className="flex items-center gap-1">
+              <NavButton onClick={() => setPage(p => Math.max(1, p - 1))} disabled={safePage === 1}><ChevronLeft className="w-3.5 h-3.5" /></NavButton>
+              {pageNumbers(safePage, totalPages).map((n, i) =>
+                n === '...'
+                  ? <span key={`e-${i}`} className="px-1 text-gray-400">...</span>
+                  : <PageButton key={n} label={n} active={n === safePage} onClick={() => setPage(n)} />
+              )}
+              <NavButton onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={safePage === totalPages}><ChevronRight className="w-3.5 h-3.5" /></NavButton>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function pageNumbers(current: number, total: number): (number | '...')[] {
+  if (total <= 5) return Array.from({ length: total }, (_, i) => i + 1);
+  const pages: (number | '...')[] = [1];
+  if (current > 3) pages.push('...');
+  for (let i = Math.max(2, current - 1); i <= Math.min(total - 1, current + 1); i++) pages.push(i);
+  if (current < total - 2) pages.push('...');
+  pages.push(total);
+  return pages;
+}
+
+function PageButton({ label, active, onClick }: { label: number; active: boolean; onClick: () => void }) {
+  return (
+    <button onClick={onClick} className={`w-7 h-7 text-xs rounded flex items-center justify-center transition-colors ${active ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}>{label}</button>
+  );
+}
+
+function NavButton({ onClick, disabled, children }: { onClick: () => void; disabled: boolean; children: React.ReactNode }) {
+  return (
+    <button onClick={onClick} disabled={disabled} className="w-7 h-7 flex items-center justify-center rounded transition-colors disabled:text-gray-300 disabled:cursor-default text-gray-600 hover:bg-gray-100 disabled:hover:bg-transparent">{children}</button>
+  );
+}
+
+function StatCard({ label, value, icon, color, sub }: {
+  label: string; value: number; icon: React.ReactNode; color: 'red' | 'purple' | 'blue' | 'green'; sub: string;
+}) {
+  const palette = {
+    red:    { bg: 'bg-red-50',    text: 'text-red-500',    border: 'border-red-100' },
+    purple: { bg: 'bg-purple-50', text: 'text-purple-500', border: 'border-purple-100' },
+    blue:   { bg: 'bg-blue-50',   text: 'text-blue-500',   border: 'border-blue-100' },
+    green:  { bg: 'bg-green-50',  text: 'text-green-500',  border: 'border-green-100' },
+  }[color];
+  return (
+    <div className={`bg-white rounded-xl p-5 border ${palette.border} shadow-sm`}>
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <p className="text-sm text-gray-500">{label}</p>
+          <p className="text-3xl font-bold text-gray-900 mt-1">{value}</p>
+          <p className="text-xs text-gray-400 mt-1">{sub}</p>
+        </div>
+        <div className={`w-10 h-10 ${palette.bg} ${palette.text} rounded-lg flex items-center justify-center shrink-0`}>{icon}</div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/hospital/nurse/settings/page.tsx
+++ b/src/app/hospital/nurse/settings/page.tsx
@@ -68,7 +68,7 @@ export default function NurseSettingsPage() {
       >
         <div>
           <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>Settings</h1>
-          <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+          <p className="mt-2 text-sm sm:text-base" style={{ color: '#0284C7' }}>
             Manage your account and preferences
           </p>
         </div>

--- a/src/app/hospital/nurse/vitals/page.tsx
+++ b/src/app/hospital/nurse/vitals/page.tsx
@@ -1,3 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { ClipboardCheck, BedDouble, AlertCircle, FilePlus } from 'lucide-react';
+
+const VITAL_FIELDS = [
+  { key: 'temperature', label: 'Temperature (/C)' },
+  { key: 'bloodPressure', label: 'Blood Pressure (mmHg)' },
+  { key: 'heartRate', label: 'Heart Rate (bpm)' },
+  { key: 'respiratoryRate', label: 'Respiratory Rate' },
+  { key: 'oxygen', label: 'Oxygen Saturation (%)' },
+  { key: 'weight', label: 'Weight (kg)' },
+] as const;
+
+const RECENT_RECORDS = [
+  { date: '20/07/25', time: '14:00', summary: 'Temp- 38.0 C BP- 120/80 HR- 72', nurse: 'Ange' },
+  { date: '19/07/25', time: '08:45', summary: 'Temp- 38.0 C BP- 120/80 HR- 72', nurse: 'Beni' },
+  { date: '10/07/25', time: '12:30', summary: 'Temp- 38.0 C BP- 120/80 HR- 72', nurse: 'Clare' },
+];
+
 export default function NurseVitalsPage() {
-  return <div />;
+  const [vitals, setVitals] = useState<Record<string, string>>({
+    temperature: '35', bloodPressure: '120/80', heartRate: '72',
+    respiratoryRate: '16', oxygen: '98', weight: '60.0',
+  });
+  const [condition, setCondition] = useState('Stable');
+  const [painLevel, setPainLevel] = useState(4);
+  const [mobility, setMobility] = useState('Independent');
+  const [observation, setObservation] = useState('Patient is alert and oriented');
+
+  return (
+    <div className="space-y-6">
+      {/* Hero */}
+      <div className="rounded-2xl p-8" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-3xl font-bold" style={{ color: '#1E3A5F' }}>Vitals and Assessments</h1>
+        <p className="mt-1 text-sm font-medium" style={{ color: '#0284C7' }}>Tracking Patients Information</p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard label="Complete Assessment" value={50} icon={<ClipboardCheck className="w-6 h-6" />} color="red"    sub="Today" />
+        <StatCard label="Admit Patients"       value={20} icon={<BedDouble className="w-6 h-6" />}     color="purple" sub="Admitted" />
+        <StatCard label="Critical Alert"        value={15} icon={<AlertCircle className="w-6 h-6" />}   color="blue"   sub="Today" />
+        <StatCard label="New Assessment"        value={25} icon={<FilePlus className="w-6 h-6" />}      color="green"  sub="Today" />
+      </div>
+
+      {/* Main grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* Vitals Entry */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <h3 className="text-base font-bold mb-4" style={{ color: '#1E3A5F' }}>Vitals Entry</h3>
+          <div className="space-y-3">
+            {VITAL_FIELDS.map(f => (
+              <div key={f.key} className="flex items-center justify-between gap-3">
+                <label className="text-sm text-gray-600">{f.label}</label>
+                <input
+                  type="text"
+                  value={vitals[f.key]}
+                  onChange={e => setVitals(v => ({ ...v, [f.key]: e.target.value }))}
+                  className="w-24 px-3 py-1.5 text-sm border border-gray-200 rounded-lg text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Assessment */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <h3 className="text-base font-bold mb-4" style={{ color: '#1E3A5F' }}>Assessment</h3>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <label className="text-sm text-gray-600">General Condition</label>
+              <select value={condition} onChange={e => setCondition(e.target.value)} className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-blue-400">
+                <option>Stable</option>
+                <option>Critical</option>
+                <option>Improving</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm text-gray-600 block mb-2">Pain Level</label>
+              <input type="range" min={0} max={10} value={painLevel} onChange={e => setPainLevel(Number(e.target.value))} className="w-full accent-blue-500" />
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <label className="text-sm text-gray-600">Mobility Status</label>
+              <select value={mobility} onChange={e => setMobility(e.target.value)} className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-blue-400">
+                <option>Independent</option>
+                <option>Assisted</option>
+                <option>Bedridden</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm text-gray-600 block mb-2">Additional Observation</label>
+              <textarea
+                value={observation}
+                onChange={e => setObservation(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Recent Records */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <h3 className="text-base font-bold mb-4" style={{ color: '#1E3A5F' }}>Recent Records</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left">
+              <thead>
+                <tr className="text-[11px] font-bold text-gray-400 uppercase tracking-wider border-b border-gray-100">
+                  <th className="pb-2 pr-2">Date</th>
+                  <th className="pb-2 pr-2">Time</th>
+                  <th className="pb-2 pr-2">Vitals Summary</th>
+                  <th className="pb-2">Nurse</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50 text-xs">
+                {RECENT_RECORDS.map((r, i) => (
+                  <tr key={i}>
+                    <td className="py-3 pr-2 text-gray-600 whitespace-nowrap">{r.date}</td>
+                    <td className="py-3 pr-2 text-gray-600">{r.time}</td>
+                    <td className="py-3 pr-2 text-gray-500">{r.summary}</td>
+                    <td className="py-3 text-gray-600">{r.nurse}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <button className="px-8 py-2.5 rounded-xl text-sm font-semibold text-white" style={{ background: '#1E3A5F' }}>
+          Save Assessment
+        </button>
+        <button className="px-8 py-2.5 rounded-xl text-sm font-semibold text-blue-600 border border-blue-200 hover:bg-blue-50 transition-colors">
+          Update Assessment
+        </button>
+        <button className="px-8 py-2.5 rounded-xl text-sm font-semibold text-gray-600 border border-gray-200 hover:bg-gray-50 transition-colors">
+          View History
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, icon, color, sub }: {
+  label: string; value: number; icon: React.ReactNode; color: 'red' | 'purple' | 'blue' | 'green'; sub: string;
+}) {
+  const palette = {
+    red:    { bg: 'bg-red-50',    text: 'text-red-500',    border: 'border-red-100' },
+    purple: { bg: 'bg-purple-50', text: 'text-purple-500', border: 'border-purple-100' },
+    blue:   { bg: 'bg-blue-50',   text: 'text-blue-500',   border: 'border-blue-100' },
+    green:  { bg: 'bg-green-50',  text: 'text-green-500',  border: 'border-green-100' },
+  }[color];
+  return (
+    <div className={`bg-white rounded-xl p-5 border ${palette.border} shadow-sm`}>
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <p className="text-sm text-gray-500">{label}</p>
+          <p className="text-3xl font-bold text-gray-900 mt-1">{value}</p>
+          <p className="text-xs text-gray-400 mt-1">{sub}</p>
+        </div>
+        <div className={`w-10 h-10 ${palette.bg} ${palette.text} rounded-lg flex items-center justify-center shrink-0`}>{icon}</div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
This PR checks the visual overall of the hospital-side portals (Doctor, Admin, Nurse) to match the Figma designs: audited every existing page, built the ones that were still empty stubs, and unified shared styling (hero headers, subtitle color, primary-button gradient). No backend/API changes as it was UI only, on mock data.

## Changes

**Doctor**
- Messages: list shows name/preview/time + unread dot (no avatars/role); default "Your Messages" empty state; wired up the search box
- Dashboard: compact hero + "Today" pill; stat cards relabeled with trend pills; donut legend + chart title restyled
- Appointments: added pagination; Doctor/Notes columns + 3-dot action; stat-card relabels
- Patient: added "Last Visit" filter; split filter bar from the table
- Prescription: segmented tabs, pale-blue toggle pills, patient-list avatars; fixed "Alternative days" overflow + stray inner scroll
- Schedule: rebuilt with List (daily) + Calendar (weekly grid) views and a calendar sidebar (mini-calendar, people search, my/other calendars)

**Admin**
- Built 4 previously-empty pages: Appointments (filter + table), Inventory (mode cards + category tabs + stock table), Schedule (calendar + sidebar), Reports & Analysis (4 recharts panels)
- Departments: rebuilt to the service-group cards + Employee Directory layout
- Dashboard / Finance / Settings: KPI relabels, uppercase stat labels, colored trends; settings tab/button colors

**Nurse**
- Built 2 previously-empty pages: Patients (stat cards + filter + table + pagination) and Vitals (vitals entry + assessment + recent records)
- Dashboard: made the My Patients / Tasks / Messages card footers clickable; restyled "Today's Schedule" (blue dots, Completed check, grey dividers)
- Set all hero backgrounds to `#EBF5FF`

**Cross-cutting**
- Unified hero subtitle color to `#0284C7` across all hospital portals
- Switched solid-fill primary CTAs (Select Department, Save Changes, Reserve Time Slot, Add Medicine) to the blue gradient

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [x] Shared / cross-cutting
- [x] Hospital Admin
- [x] Doctor
- [x] Nurse

## How to test
1. `npm run build`: confirm it compiles clean
2. Doctor (`/hospital/doctor/...`): dashboard, appointments (paginate), patient (Last Visit filter), prescription (pick "Alternative days" stays inside the card), messages (search + empty state), schedule (toggle List and Calendar)
3. Admin (`/hospital/admin/...`): appointments, inventory (category tabs), schedule, reports (charts render), departments (service cards + directory), finance, staff, settings
4. Nurse (`/hospital/nurse/...`): patients, vitals, dashboard (card footers navigate; "Today's Schedule" styling), and confirm every hero is the pale-blue `#EBF5FF`

## Checklist
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw`: most new copy is hardcoded English; fr/rw not yet added
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable: raw hex used throughout (e.g. `#0284C7`, `#EBF5FF`); to be addressed in a follow-up
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->