### PR TITLE
fix: new updates on the ui of the receptionist portal to match figma …

### DIFF
--- a/src/app/hospital/receptionist/dashboard/page.tsx
+++ b/src/app/hospital/receptionist/dashboard/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell,
+} from 'recharts';
+import { Users, ChevronRight } from 'lucide-react';
+import { MOCK_RECEPTIONIST } from '@/mock/hospital/user';
+import {
+  MOCK_NEW_PATIENTS_WEEK,
+  MOCK_CHECKINS_WEEK,
+  MOCK_QUEUE,
+  MOCK_TODAY_APPOINTMENTS,
+  type QueueStatus,
+  type TodayAppointmentStatus,
+} from '@/mock/hospital/receptionist';
+
+const NAVY = '#1E3A5F';
+const TEAL = '#38BDF8';
+
+const BAR_COLORS = ['#1D4ED8', '#60A5FA', '#38BDF8', '#2563EB', '#3B82F6', '#1E40AF', '#0EA5E9'];
+
+const queueStatusStyles: Record<QueueStatus, { bg: string; color: string; label: string }> = {
+  WAITING:         { bg: '#EBF5FF', color: '#2563EB', label: 'Waiting' },
+  IN_CONSULTATION: { bg: '#ECFDF5', color: '#059669', label: 'In-Consultation' },
+  COMPLETED:       { bg: '#F1F5F9', color: '#475569', label: 'Completed' },
+};
+
+const apptStatusStyles: Record<TodayAppointmentStatus, { bg: string; color: string; label: string }> = {
+  COMPLETED:  { bg: '#ECFDF5', color: '#059669', label: 'Completed' },
+  UPCOMING:   { bg: '#EFF6FF', color: '#2563EB', label: 'Upcoming' },
+  CHECKED_IN: { bg: '#EEF2FF', color: '#4F46E5', label: 'Checked In' },
+};
+
+export default function ReceptionistDashboardPage() {
+  const firstName = MOCK_RECEPTIONIST.firstName;
+
+  // ResponsiveContainer can't measure its parent during SSR / first paint
+  // (reads width/height = -1). Render charts only after mount, when the
+  // container has a real size.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <div className="space-y-6">
+
+      {/* ── Hero header ── */}
+      <div className="rounded-2xl px-6 sm:px-10 py-8" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>
+          Welcome Back, {firstName}
+        </h1>
+        <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+          Here&apos;s what&apos;s happening at the front desk today.
+        </p>
+      </div>
+
+      {/* ── Charts ── */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* New Patients this week */}
+        <div className="bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
+          <h3 className="text-sm font-bold text-center mb-4" style={{ color: NAVY }}>
+            New Patients this week
+          </h3>
+          <div className="h-56">
+            {mounted && (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={MOCK_NEW_PATIENTS_WEEK} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                  <CartesianGrid vertical={false} stroke="#F1F5F9" />
+                  <XAxis dataKey="label" axisLine={false} tickLine={false} tick={{ fontSize: 11, fill: '#94A3B8' }} />
+                  <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 11, fill: '#94A3B8' }} domain={[0, 400]} />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="value" stroke={TEAL} strokeWidth={2}
+                    dot={{ r: 4, fill: '#fff', stroke: TEAL, strokeWidth: 2 }} activeDot={{ r: 5 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+
+        {/* Check-ins This Week */}
+        <div className="bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
+          <h3 className="text-sm font-bold text-center mb-4" style={{ color: NAVY }}>
+            Check-ins This Week
+          </h3>
+          <div className="h-56">
+            {mounted && (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={MOCK_CHECKINS_WEEK} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                  <CartesianGrid vertical={false} stroke="#F1F5F9" />
+                  <XAxis dataKey="label" axisLine={false} tickLine={false} tick={{ fontSize: 11, fill: '#94A3B8' }} />
+                  <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 11, fill: '#94A3B8' }} domain={[0, 200]} />
+                  <Tooltip cursor={{ fill: '#F8FAFC' }} />
+                  <Bar dataKey="value" radius={[6, 6, 0, 0]} barSize={22}>
+                    {MOCK_CHECKINS_WEEK.map((_, i) => (
+                      <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Check-ins & Queue overview ── */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <Users size={18} style={{ color: TEAL }} />
+            <h2 className="text-base font-bold" style={{ color: NAVY }}>Check-ins &amp; Queue overview</h2>
+          </div>
+          <button className="text-sm font-semibold" style={{ color: TEAL }}>View All</button>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                <th className="py-3 px-4 rounded-l-lg">#</th>
+                <th className="py-3 px-4">Patient Name</th>
+                <th className="py-3 px-4">Token No.</th>
+                <th className="py-3 px-4">Department</th>
+                <th className="py-3 px-4 text-right rounded-r-lg">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 text-sm">
+              {MOCK_QUEUE.map((row, idx) => {
+                const s = queueStatusStyles[row.status];
+                return (
+                  <tr key={row.id} className="hover:bg-gray-50/60 transition-colors">
+                    <td className="py-4 px-4 text-gray-500">{idx + 1}</td>
+                    <td className="py-4 px-4 font-medium text-gray-800">{row.patientName}</td>
+                    <td className="py-4 px-4 text-gray-600">{row.token}</td>
+                    <td className="py-4 px-4 text-gray-600">{row.department}</td>
+                    <td className="py-4 px-4 text-right">
+                      <span
+                        className="inline-flex px-3 py-1 rounded-full text-xs font-semibold"
+                        style={{ backgroundColor: s.bg, color: s.color }}
+                      >
+                        {s.label}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex justify-center mt-6">
+          <button
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors hover:bg-blue-100"
+            style={{ backgroundColor: '#EBF5FF', color: '#2563EB' }}
+          >
+            <Users size={16} />
+            Manage Queue
+          </button>
+        </div>
+      </div>
+
+      {/* ── Today's Appointments ── */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <svg className="w-5 h-5" fill="none" stroke={TEAL} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <h2 className="text-base font-bold" style={{ color: NAVY }}>Today&apos;s Appointments</h2>
+          </div>
+          <button className="text-sm font-semibold" style={{ color: TEAL }}>View All</button>
+        </div>
+
+        <div className="divide-y divide-gray-100">
+          {MOCK_TODAY_APPOINTMENTS.map((appt) => {
+            const s = apptStatusStyles[appt.status];
+            return (
+              <button
+                key={appt.id}
+                className="w-full flex items-center gap-4 py-4 text-left hover:bg-gray-50/60 transition-colors rounded-lg px-2"
+              >
+                <span className="w-20 text-sm font-semibold text-gray-700 shrink-0">{appt.time}</span>
+                <span className="flex-1 text-sm font-medium text-gray-800">{appt.patientName}</span>
+                <span className="flex-1 text-sm text-gray-500 hidden sm:block">{appt.doctorName}</span>
+                <span
+                  className="inline-flex px-3 py-1 rounded-full text-xs font-semibold shrink-0"
+                  style={{ backgroundColor: s.bg, color: s.color }}
+                >
+                  {s.label}
+                </span>
+                <ChevronRight size={18} className="text-gray-400 shrink-0" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hospital/receptionist/layout.tsx
+++ b/src/app/hospital/receptionist/layout.tsx
@@ -1,5 +1,3 @@
-//src/app/hospital/receptionist/layout.tsx
-
 'use client';
 
 import { useState } from 'react';

--- a/src/app/hospital/receptionist/notifications/page.tsx
+++ b/src/app/hospital/receptionist/notifications/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Search, Check, ChevronLeft, ChevronRight,
+  CalendarPlus, UserPlus, ClipboardCheck, Megaphone,
+} from 'lucide-react';
+import {
+  MOCK_RECEPTIONIST_NOTIFICATIONS,
+  type ReceptionistNotification,
+  type ReceptionistNotificationType,
+} from '@/mock/hospital/receptionist';
+
+const NAVY = '#1E3A5F';
+const TEAL = '#38BDF8';
+
+type Tab = 'all' | 'unread' | 'read';
+
+const iconConfig: Record<ReceptionistNotificationType, { Icon: typeof CalendarPlus; bg: string; color: string }> = {
+  APPOINTMENT_BOOKED:   { Icon: CalendarPlus,    bg: '#EBF5FF', color: '#2563EB' },
+  PATIENT_REGISTERED:   { Icon: UserPlus,        bg: '#EEF2FF', color: '#4F46E5' },
+  APPOINTMENT_REMINDER: { Icon: ClipboardCheck,  bg: '#ECFEFF', color: '#0891B2' },
+  SYSTEM:               { Icon: Megaphone,       bg: '#EFF6FF', color: '#3B82F6' },
+};
+
+export default function ReceptionistNotificationsPage() {
+  const [items, setItems] = useState<ReceptionistNotification[]>(MOCK_RECEPTIONIST_NOTIFICATIONS);
+  const [tab, setTab] = useState<Tab>('all');
+  const [query, setQuery] = useState('');
+
+  const unreadCount = items.filter((n) => !n.isRead).length;
+
+  const markAllRead = () => setItems((prev) => prev.map((n) => ({ ...n, isRead: true })));
+  const markRead = (id: string) =>
+    setItems((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
+
+  const filtered = useMemo(() => {
+    return items.filter((n) => {
+      if (tab === 'unread' && n.isRead) return false;
+      if (tab === 'read' && !n.isRead) return false;
+      if (query.trim()) {
+        const q = query.toLowerCase();
+        return n.title.toLowerCase().includes(q) || n.message.toLowerCase().includes(q);
+      }
+      return true;
+    });
+  }, [items, tab, query]);
+
+  const tabs: { key: Tab; label: string; badge?: number }[] = [
+    { key: 'all',    label: 'All' },
+    { key: 'unread', label: 'Unread', badge: unreadCount },
+    { key: 'read',   label: 'Read' },
+  ];
+
+  return (
+    <div className="space-y-6">
+
+      {/* ── Hero header ── */}
+      <div className="rounded-2xl px-6 sm:px-10 py-7" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>Notifications</h1>
+        <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>View recent updates.</p>
+      </div>
+
+      {/* ── Search ── */}
+      <div className="relative">
+        <Search size={18} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search notifications......"
+          className="w-full bg-white border border-gray-200 rounded-xl pl-11 pr-4 py-3 text-sm text-gray-700 outline-none focus:ring-2 transition-all"
+          style={{ '--tw-ring-color': TEAL } as React.CSSProperties}
+        />
+      </div>
+
+      {/* ── List card ── */}
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 sm:p-6">
+
+        {/* Tabs + mark all */}
+        <div className="flex items-center justify-between border-b border-gray-100 pb-3 mb-2">
+          <div className="flex items-center gap-5">
+            {tabs.map((t) => (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`relative flex items-center gap-1.5 pb-2 text-sm font-semibold transition-colors ${
+                  tab === t.key ? '' : 'text-gray-500 hover:text-gray-700'
+                }`}
+                style={tab === t.key ? { color: '#2563EB' } : {}}
+              >
+                {t.label}
+                {t.badge ? (
+                  <span
+                    className="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-[11px] font-bold text-white"
+                    style={{ backgroundColor: '#2563EB' }}
+                  >
+                    {t.badge}
+                  </span>
+                ) : null}
+                {tab === t.key && (
+                  <span className="absolute left-0 -bottom-[13px] h-0.5 w-full rounded-full" style={{ backgroundColor: '#2563EB' }} />
+                )}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={markAllRead}
+            className="flex items-center gap-1.5 text-sm font-semibold transition-colors hover:opacity-80"
+            style={{ color: '#2563EB' }}
+          >
+            <Check size={15} />
+            <span className="hidden sm:inline">Mark all as read</span>
+          </button>
+        </div>
+
+        {/* Items */}
+        {filtered.length === 0 ? (
+          <p className="text-center text-gray-400 text-sm py-12">No notifications found.</p>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {filtered.map((n) => {
+              const cfg = iconConfig[n.type];
+              const Icon = cfg.Icon;
+              return (
+                <div
+                  key={n.id}
+                  onClick={() => markRead(n.id)}
+                  className="flex items-start gap-4 py-4 cursor-pointer transition-colors hover:bg-gray-50/60 rounded-lg px-2"
+                >
+                  {/* Unread dot */}
+                  <span className="pt-2 w-2.5 shrink-0">
+                    {!n.isRead && (
+                      <span className="block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: '#2563EB' }} />
+                    )}
+                  </span>
+
+                  {/* Icon badge */}
+                  <div
+                    className="w-11 h-11 rounded-full flex items-center justify-center shrink-0"
+                    style={{ backgroundColor: cfg.bg }}
+                  >
+                    <Icon size={20} style={{ color: cfg.color }} />
+                  </div>
+
+                  {/* Text */}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-gray-900 text-sm">{n.title}</p>
+                    <p className="text-sm text-gray-400 mt-0.5">{n.message}</p>
+                  </div>
+
+                  {/* Time */}
+                  <span className="text-xs text-gray-400 shrink-0 whitespace-nowrap pt-0.5">{n.time}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Pagination */}
+        <div className="flex items-center justify-end gap-2 mt-6">
+          <button className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors" aria-label="Previous">
+            <ChevronLeft size={16} />
+          </button>
+          {[1, 2, 3].map((page) => (
+            <button
+              key={page}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-sm font-semibold transition-colors"
+              style={page === 1
+                ? { backgroundColor: '#2563EB', color: '#fff' }
+                : { border: '1px solid #E5E7EB', color: '#6B7280' }}
+            >
+              {page}
+            </button>
+          ))}
+          <button className="w-8 h-8 flex items-center justify-center rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 transition-colors" aria-label="Next">
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hospital/receptionist/profile/page.tsx
+++ b/src/app/hospital/receptionist/profile/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { User, Mail, Phone, Calendar, Pencil } from 'lucide-react';
+import { MOCK_RECEPTIONIST_PROFILE } from '@/mock/hospital/receptionist';
+
+const NAVY     = '#1E3A5F';
+const TEAL     = '#38BDF8';
+const GRADIENT = 'linear-gradient(90deg, #0284C7 0%, #38BDF8 100%)';
+
+const inputCls =
+  'w-full border border-gray-200 rounded-xl px-4 text-sm text-gray-700 outline-none ' +
+  'focus:ring-2 disabled:bg-white disabled:text-gray-600 transition-all min-h-11';
+
+const labelCls = 'block text-sm font-medium text-gray-700 mb-2';
+
+export default function ReceptionistProfilePage() {
+  const p = MOCK_RECEPTIONIST_PROFILE;
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState({
+    fullName:      p.fullName,
+    phone:         p.phone,
+    email:         p.email,
+    username:      p.username,
+    department:    p.department,
+    address:       p.address,
+    dateOfJoining: p.dateOfJoining,
+  });
+
+  const set = (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((f) => ({ ...f, [key]: e.target.value }));
+
+  const [avatar, setAvatar] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setAvatar(reader.result as string);
+    reader.readAsDataURL(file);
+    // reset so selecting the same file again still fires onChange
+    e.target.value = '';
+  };
+
+  return (
+    <div className="space-y-6">
+
+      {/* ── Hero header ── */}
+      <div className="rounded-2xl px-6 sm:px-10 py-7" style={{ background: '#EBF5FF' }}>
+        <h1 className="text-3xl sm:text-4xl font-bold" style={{ color: NAVY }}>My Profile</h1>
+        <p className="mt-2 text-sm sm:text-base" style={{ color: TEAL }}>
+          Update your personal information
+        </p>
+      </div>
+
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
+
+        {/* ── Profile summary card ── */}
+        <div className="w-full lg:w-80 lg:shrink-0 bg-white rounded-2xl border border-gray-100 shadow-sm p-6 sm:p-7">
+          <div className="flex flex-col items-center text-center">
+            <div className="relative">
+              <div
+                className="w-24 h-24 rounded-full flex items-center justify-center overflow-hidden"
+                style={{ backgroundColor: '#EBF5FF' }}
+              >
+                {avatar ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={avatar} alt="Profile" className="w-full h-full object-cover" />
+                ) : (
+                  <User size={44} style={{ color: '#2563EB' }} />
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleAvatarChange}
+                className="hidden"
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="absolute bottom-1 right-1 bg-white rounded-full p-1 shadow border border-gray-100 transition-transform hover:scale-110"
+                aria-label="Change photo"
+              >
+                <Pencil size={13} style={{ color: '#2563EB' }} />
+              </button>
+            </div>
+            <p className="mt-4 font-bold text-lg text-gray-900">{p.fullName}</p>
+            <p className="text-sm text-gray-400 mt-0.5">{p.jobTitle}</p>
+            <span
+              className="mt-3 inline-flex px-4 py-1 rounded-full text-xs font-semibold"
+              style={{ backgroundColor: '#EBF5FF', color: '#2563EB' }}
+            >
+              {p.roleLabel}
+            </span>
+          </div>
+
+          <div className="border-t border-gray-100 my-5" />
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-3 text-sm text-gray-500">
+              <Mail size={16} style={{ color: TEAL }} className="shrink-0" />
+              <span className="break-all">{p.email}</span>
+            </div>
+            <div className="flex items-center gap-3 text-sm text-gray-500">
+              <Phone size={16} style={{ color: TEAL }} className="shrink-0" />
+              <span>{p.phone}</span>
+            </div>
+            <div className="flex items-center gap-3 text-sm text-gray-500">
+              <Calendar size={16} style={{ color: TEAL }} className="shrink-0" />
+              <span>Joined on {p.joinedAt}</span>
+            </div>
+          </div>
+
+          <button
+            onClick={() => setEditing((v) => !v)}
+            className="mt-6 w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-blue-50"
+            style={{ borderColor: '#2563EB', color: '#2563EB' }}
+          >
+            <Pencil size={14} />
+            {editing ? 'Cancel' : 'Edit Profile'}
+          </button>
+        </div>
+
+        {/* ── Personal information form ── */}
+        <div className="flex-1 w-full bg-white rounded-2xl border border-gray-100 shadow-sm p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="rounded-full p-2" style={{ backgroundColor: '#EBF5FF' }}>
+              <User size={18} style={{ color: '#2563EB' }} />
+            </div>
+            <h2 className="text-base font-bold" style={{ color: NAVY }}>Personal Information</h2>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+            <div>
+              <label className={labelCls}>Full Name</label>
+              <input type="text" value={form.fullName} disabled={!editing} onChange={set('fullName')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+            <div>
+              <label className={labelCls}>Phone Number</label>
+              <input type="text" value={form.phone} disabled={!editing} onChange={set('phone')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className={labelCls}>Email Address</label>
+              <input type="email" value={form.email} disabled={!editing} onChange={set('email')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+
+            <div>
+              <label className={labelCls}>Username</label>
+              <input type="text" value={form.username} disabled={!editing} onChange={set('username')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+            <div>
+              <label className={labelCls}>Department</label>
+              <input type="text" value={form.department} disabled={!editing} onChange={set('department')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className={labelCls}>Address</label>
+              <input type="text" value={form.address} disabled={!editing} onChange={set('address')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className={labelCls}>Date of joining</label>
+              <input type="date" value={form.dateOfJoining} disabled={!editing} onChange={set('dateOfJoining')}
+                className={inputCls} style={{ '--tw-ring-color': TEAL } as React.CSSProperties} />
+            </div>
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <button
+              disabled={!editing}
+              onClick={() => setEditing(false)}
+              className="px-10 min-h-11 rounded-xl text-white text-sm font-semibold transition-all hover:opacity-80 disabled:opacity-30"
+              style={{ background: GRADIENT }}
+            >
+              Save Changes
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/hospital/HospitalSidebar.tsx
+++ b/src/components/hospital/HospitalSidebar.tsx
@@ -19,6 +19,7 @@ import {
   BarChart2,
   LogOut,
   X,
+  User,
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 
@@ -61,10 +62,13 @@ const NURSE_NAV = [
 
 //Added receptionist navigation
 const RECEPTIONIST_NAV = [
+  { href: '/hospital/receptionist/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
   { href: '/hospital/receptionist/appointment-list', icon: CalendarDays, label: 'Appointments' },
-  { href: '/hospital/receptionist/change-password', icon: UserCog, label: 'Change Password' },
   { href: '/hospital/receptionist/checkingQueue', icon: Clock, label: 'Checking Queue' },
   { href: '/hospital/receptionist/leave-request', icon: Users, label: 'Leave Request' },
+  { href: '/hospital/receptionist/notifications', icon: Bell, label: 'Notifications' },
+  { href: '/hospital/receptionist/profile', icon: User, label: 'Profile' },
+  { href: '/hospital/receptionist/change-password', icon: UserCog, label: 'Change Password' },
 ]
 
 const NAV_MAP = {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -249,14 +249,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           break;
 
         case 'RECEPTIONIST':
-          // No frontend portal exists for this role yet — see auth
-          // integration gap doc. Do not silently log them into an
-          // unfinished/incorrect portal.
-          toast.error('The receptionist portal is not available yet. Please contact your hospital admin.');
-          removeAuthTokens();
-          clearUserCache();
-          setUser(null);
-          router.push('/login');
+          toast.success('Welcome back!');
+          router.push('/hospital/receptionist/dashboard');
           break;
 
         default:

--- a/src/mock/hospital/receptionist.ts
+++ b/src/mock/hospital/receptionist.ts
@@ -1,0 +1,132 @@
+// Mock data for the receptionist (front desk) portal.
+// Frontend-only: replace with real endpoints once the receptionist API is ready.
+
+// ── Dashboard charts ──────────────────────────────────────────────────────────
+
+export interface ReceptionistDailyPoint {
+  label: string;   // Mon, Tue, ...
+  value: number;
+}
+
+export const MOCK_NEW_PATIENTS_WEEK: ReceptionistDailyPoint[] = [
+  { label: 'Mon', value: 200 },
+  { label: 'Tue', value: 300 },
+  { label: 'Wed', value: 200 },
+  { label: 'Thu', value: 90 },
+  { label: 'Fri', value: 230 },
+  { label: 'Sat', value: 220 },
+  { label: 'Sun', value: 190 },
+];
+
+export const MOCK_CHECKINS_WEEK: ReceptionistDailyPoint[] = [
+  { label: 'Mon', value: 110 },
+  { label: 'Tue', value: 185 },
+  { label: 'Wed', value: 150 },
+  { label: 'Thu', value: 70 },
+  { label: 'Fri', value: 60 },
+  { label: 'Sat', value: 105 },
+  { label: 'Sun', value: 120 },
+];
+
+// ── Check-ins & Queue overview ────────────────────────────────────────────────
+
+export type QueueStatus = 'WAITING' | 'IN_CONSULTATION' | 'COMPLETED';
+
+export interface QueueEntry {
+  id: string;
+  patientName: string;
+  token: string;
+  department: string;
+  status: QueueStatus;
+}
+
+export const MOCK_QUEUE: QueueEntry[] = [
+  { id: 'q-1', patientName: 'Mugisha Arsene', token: 'T-101', department: 'General Medicine', status: 'WAITING' },
+  { id: 'q-2', patientName: 'Atete Solange',  token: 'T-102', department: 'Dermatology',      status: 'WAITING' },
+  { id: 'q-3', patientName: 'Butera Ammy',    token: 'T-103', department: 'Orthopedics',      status: 'IN_CONSULTATION' },
+];
+
+// ── Today's appointments ──────────────────────────────────────────────────────
+
+export type TodayAppointmentStatus = 'COMPLETED' | 'UPCOMING' | 'CHECKED_IN';
+
+export interface TodayAppointment {
+  id: string;
+  time: string;
+  patientName: string;
+  doctorName: string;
+  status: TodayAppointmentStatus;
+}
+
+export const MOCK_TODAY_APPOINTMENTS: TodayAppointment[] = [
+  { id: 'a-1', time: '9:30 AM',  patientName: 'Mugisha Arsene', doctorName: 'Dr. Damascene', status: 'COMPLETED' },
+  { id: 'a-2', time: '10:00 AM', patientName: 'Atete Solange',  doctorName: 'Dr. Mutoni Ivy', status: 'UPCOMING' },
+  { id: 'a-3', time: '10:30 AM', patientName: 'Butera Ammy',    doctorName: 'Dr. Abera Joy',  status: 'CHECKED_IN' },
+];
+
+// ── Notifications ─────────────────────────────────────────────────────────────
+
+export type ReceptionistNotificationType =
+  | 'APPOINTMENT_BOOKED'
+  | 'PATIENT_REGISTERED'
+  | 'APPOINTMENT_REMINDER'
+  | 'SYSTEM';
+
+export interface ReceptionistNotification {
+  id: string;
+  type: ReceptionistNotificationType;
+  title: string;
+  message: string;
+  time: string;
+  isRead: boolean;
+}
+
+export const MOCK_RECEPTIONIST_NOTIFICATIONS: ReceptionistNotification[] = [
+  {
+    id: 'n-1',
+    type: 'APPOINTMENT_BOOKED',
+    title: 'New Appointment Booked',
+    message: 'A new appointment has been booked with Dr. Ammy on August 20, 2026',
+    time: '2min ago',
+    isRead: false,
+  },
+  {
+    id: 'n-2',
+    type: 'PATIENT_REGISTERED',
+    title: 'New Patient Registered',
+    message: 'Annet Mutesi has been successfully registered',
+    time: '15min ago',
+    isRead: false,
+  },
+  {
+    id: 'n-3',
+    type: 'APPOINTMENT_REMINDER',
+    title: 'Appointment Remainder',
+    message: 'Appointment remainder has been sent to Mugisha Tom on July 16, 2026',
+    time: '1hr ago',
+    isRead: false,
+  },
+  {
+    id: 'n-4',
+    type: 'SYSTEM',
+    title: 'System Notification',
+    message: 'Scheduled maintenance on May 20, 2027 from 1:00AM to 3:30AM',
+    time: '3hrs ago',
+    isRead: true,
+  },
+];
+
+// ── Profile ───────────────────────────────────────────────────────────────────
+
+export const MOCK_RECEPTIONIST_PROFILE = {
+  fullName: 'Receptionist',
+  jobTitle: 'Front Desk',
+  roleLabel: 'Receptionist',
+  email: 'receptionist@medplus.com',
+  phone: '+250758948349',
+  username: 'receptionist',
+  department: 'Front Desk',
+  address: 'KG 11 Ave, Kigali',
+  joinedAt: 'Jan 10, 2024',
+  dateOfJoining: '2024-01-10',
+};


### PR DESCRIPTION
## Summary
This PR adds the Receptionist portal 3 other features which are dashboard, notifications, and profile pages, plus all supporting mock data, types, sidebar nav, and auth routing. No backend/API changes; UI only, on mock data.

## Changes

**Receptionist portal (`src/app/hospital/receptionist/`)**
- `dashboard/page.tsx`: "Welcome Back" hero, New Patients line chart + Check-ins bar chart (mount-gated to prevent Recharts `width(-1)` warning), Check-ins & Queue table with Manage Queue action, and Today's Appointments list
- `notifications/page.tsx`: search bar, All / Unread / Read tabs, Mark all as read, icon notification rows, pagination
- `profile/page.tsx`: summary card (avatar with working photo upload, role badge, email/phone/joined date) and Personal Information form with gradient Save Changes button
- `layout.tsx`: wraps pages in shared `HospitalSidebar` + `HospitalTopbar` using `MOCK_RECEPTIONIST`

**Supporting files**
- `src/mock/hospital/receptionist.ts`: all mock data (charts, queue, appointments, notifications, profile)
- `src/types/hospital.ts`: added `MockReceptionist` type
- `src/mock/hospital/user.ts`: added `MOCK_RECEPTIONIST`
- `src/components/hospital/HospitalSidebar.tsx`: added `receptionist` portal type + nav links for all 7 pages
- `src/context/AuthContext.tsx`: changed `RECEPTIONIST` login case from redirecting to `/login` to routing to `/hospital/receptionist/dashboard`

**Note:** `appointments`, `checkingQueue`, `leave-request`, and `change-password` pages also appear in this branch — these came from the teammate's work merged in from `dev` and are not part of this contribution.

## Affected portals / areas
- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [x] Shared / cross-cutting
- [x] Hospital: Receptionist portal

## How to test
1. `npm run build` — confirm it compiles clean with 0 type errors
2. Log in as a receptionist (or bypass auth for local testing) and visit `/hospital/receptionist/dashboard`, so hero, both charts, queue table, and appointments list should render
3. Visit `/hospital/receptionist/notifications`: tabs (All / Unread / Read) filter correctly; Mark all as read clears the unread count
4. Visit `/hospital/receptionist/profile` — summary card shows mock data; clicking the pencil icon opens a file picker and the selected image replaces the avatar live
5. Confirm sidebar shows all 7 receptionist nav links and highlights the active page
6. Log in via the hospital login: confirm a `RECEPTIONIST` role is routed to `/hospital/receptionist/dashboard` instead of `/login`

## Checklist
- [x] `npm run build` passes clean (type-check included)
- [x] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw`
- [ ] Used design tokens / `StatusBadge` instead of raw hex: raw hex used (e.g. `#0284C7`, `#38BDF8`); to be addressed in a follow-up
- [x] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Related issues
<!-- e.g. Closes #123 -->