### PR TITLE
Tita integration

### DIFF
--- a/src/app/hospital/admin/dashboard/page.tsx
+++ b/src/app/hospital/admin/dashboard/page.tsx
@@ -25,10 +25,14 @@ export default function HospitalAdminDashboardPage() {
 
   const firstName = userName.split(' ')[0];
 
-  const [apiStats, setApiStats]       = useState<DashboardStats | null>(null);
-  const [chartData, setChartData]     = useState<{ label: string; value: number }[]>([]);
+  const [apiStats, setApiStats]           = useState<DashboardStats | null>(null);
+  const [spendData, setSpendData]         = useState<{ label: string; value: number }[]>([]);
+  const [volumeData, setVolumeData]       = useState<{ label: string; value: number }[]>([]);
+  const [chartMode, setChartMode]         = useState<'spend' | 'volume'>('spend');
   const [lowStockCount, setLowStockCount] = useState<number | null>(null);
-  const [loading, setLoading]         = useState(true);
+  const [loading, setLoading]             = useState(true);
+
+  const chartData = chartMode === 'spend' ? spendData : volumeData;
 
   const getGreeting = () => {
     const h = new Date().getHours();
@@ -40,9 +44,10 @@ export default function HospitalAdminDashboardPage() {
   useEffect(() => {
     if (!hospitalId) { setLoading(false); return; }
     (async () => {
-      const [statsRes, revenueRes, stockRes] = await Promise.allSettled([
+      const [statsRes, revenueRes, appointmentsRes, stockRes] = await Promise.allSettled([
         api.get(`/hospitals/${hospitalId}/dashboard/stats`),
         api.get(`/hospitals/${hospitalId}/dashboard/weekly-revenue`),
+        api.get(`/hospitals/${hospitalId}/dashboard/daily-appointments`),
         api.get(`/hospitals/${hospitalId}/drug-stock`),
       ]);
       if (statsRes.status === 'fulfilled')
@@ -51,7 +56,13 @@ export default function HospitalAdminDashboardPage() {
         const rows: { label: string; revenue: number }[] = Array.isArray(revenueRes.value.data)
           ? revenueRes.value.data
           : [];
-        setChartData(rows.map(r => ({ label: r.label, value: r.revenue })));
+        setSpendData(rows.map(r => ({ label: r.label, value: r.revenue })));
+      }
+      if (appointmentsRes.status === 'fulfilled') {
+        const rows: { label: string; count: number }[] = Array.isArray(appointmentsRes.value.data)
+          ? appointmentsRes.value.data
+          : [];
+        setVolumeData(rows.map(r => ({ label: r.label, value: r.count })));
       }
       if (stockRes.status === 'fulfilled') {
         const items = Array.isArray(stockRes.value.data) ? stockRes.value.data : [];
@@ -184,26 +195,42 @@ export default function HospitalAdminDashboardPage() {
             <div>
               <h2 className="text-lg font-semibold text-slate-900">{t('hospital.monthlyLogistics')}</h2>
             </div>
-            <div className="flex items-center gap-2 bg-slate-100 rounded-full p-1" aria-label='Show spend chart'>
-              <button className="rounded-full px-4 py-2 text-sm font-semibold text-white bg-brand-navy shadow-sm transition hover:bg-brand-navy/5">
+            <div className="flex items-center gap-2 bg-slate-100 rounded-full p-1">
+              <button
+                onClick={() => setChartMode('spend')}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${chartMode === 'spend' ? 'text-white bg-brand-navy shadow-sm' : 'text-slate-500 hover:bg-slate-200'}`}
+              >
                 {t('hospital.spend')}
               </button>
-              <button className="rounded-full px-4 py-2 text-sm font-semibold text-slate-500 transition hover:bg-slate-200">
+              <button
+                onClick={() => setChartMode('volume')}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${chartMode === 'volume' ? 'text-white bg-brand-navy shadow-sm' : 'text-slate-500 hover:bg-slate-200'}`}
+              >
                 {t('hospital.volume')}
               </button>
             </div>
           </div>
 
           <div className="h-[300px]">
-            {!loading && chartData.length === 0 ? (
-              <div className="flex items-center justify-center h-full text-sm text-gray-400">No revenue data available</div>
+            {loading ? (
+              <div className="h-full rounded-xl bg-gray-100 animate-pulse" />
+            ) : chartData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-sm text-gray-400">
+                {chartMode === 'spend' ? 'No revenue data available' : 'No appointment data available'}
+              </div>
             ) : (
               <ResponsiveContainer width="98%" height="100%">
                 <LineChart data={chartData}>
                   <CartesianGrid vertical={false} />
                   <XAxis dataKey="label" axisLine={false} tickLine={false} />
                   <YAxis axisLine={false} tickLine={false} />
-                  <Tooltip formatter={(v) => [`${(v as number).toLocaleString()} RWF`, 'Revenue']} />
+                  <Tooltip
+                    formatter={(v) =>
+                      chartMode === 'spend'
+                        ? [`${(v as number).toLocaleString()} RWF`, 'Revenue']
+                        : [`${(v as number).toLocaleString()}`, 'Appointments']
+                    }
+                  />
                   <Line type="monotone" dataKey="value" dot={false} />
                 </LineChart>
               </ResponsiveContainer>

--- a/src/app/hospital/admin/dashboard/page.tsx
+++ b/src/app/hospital/admin/dashboard/page.tsx
@@ -1,17 +1,35 @@
 // src/app/hospital/admin/dashboard/page.tsx
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import { useHospitalAdminUser } from '@/lib/hospital';
+import { useHospitalAdminUser, useHospitalId } from '@/lib/hospital';
 import { CalendarIcon, UsersIcon, BanknotesIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import api from '@/lib/api';
+
+interface DashboardStats {
+  totalAppointments: { thisMonth: number; allTime: number };
+  totalRevenue: number;
+  monthlyRevenue: number;
+  totalDoctors: number;
+  activeDoctors: number;
+  totalPatients: number;
+}
 
 export default function HospitalAdminDashboardPage() {
   const { t } = useTranslation();
   const { userName } = useHospitalAdminUser();
+  const hospitalId = useHospitalId();
 
   const firstName = userName.split(' ')[0];
+
+  const [apiStats, setApiStats]       = useState<DashboardStats | null>(null);
+  const [chartData, setChartData]     = useState<{ label: string; value: number }[]>([]);
+  const [lowStockCount, setLowStockCount] = useState<number | null>(null);
+  const [loading, setLoading]         = useState(true);
+
   const getGreeting = () => {
     const h = new Date().getHours();
     if (h < 12) return t('hospital.goodMorning');
@@ -19,11 +37,35 @@ export default function HospitalAdminDashboardPage() {
     return t('hospital.goodEvening');
   };
 
+  useEffect(() => {
+    if (!hospitalId) { setLoading(false); return; }
+    (async () => {
+      const [statsRes, revenueRes, stockRes] = await Promise.allSettled([
+        api.get(`/hospitals/${hospitalId}/dashboard/stats`),
+        api.get(`/hospitals/${hospitalId}/dashboard/weekly-revenue`),
+        api.get(`/hospitals/${hospitalId}/drug-stock`),
+      ]);
+      if (statsRes.status === 'fulfilled')
+        setApiStats(statsRes.value.data);
+      if (revenueRes.status === 'fulfilled') {
+        const rows: { label: string; revenue: number }[] = Array.isArray(revenueRes.value.data)
+          ? revenueRes.value.data
+          : [];
+        setChartData(rows.map(r => ({ label: r.label, value: r.revenue })));
+      }
+      if (stockRes.status === 'fulfilled') {
+        const items = Array.isArray(stockRes.value.data) ? stockRes.value.data : [];
+        setLowStockCount(items.filter((d: any) => d.lowStockAlert).length);
+      }
+      setLoading(false);
+    })();
+  }, [hospitalId]);
+
   const stats = [
     {
       label: t('hospital.appointments'),
-      value: 9,
-      statusText: '18% vs yesterday',
+      value: loading ? '—' : (apiStats?.totalAppointments.thisMonth ?? '—'),
+      statusText: apiStats ? `${apiStats.totalAppointments.allTime} all time` : '—',
       statusColor: 'text-emerald-600',
       up: true,
       accent: 'border-brand-navy',
@@ -34,8 +76,8 @@ export default function HospitalAdminDashboardPage() {
     },
     {
       label: t('hospital.activeDoctors'),
-      value: 6,
-      statusText: t('hospital.onDutyToday'),
+      value: loading ? '—' : (apiStats?.activeDoctors ?? '—'),
+      statusText: apiStats ? `${apiStats.totalDoctors} total doctors` : '—',
       statusColor: 'text-slate-500',
       up: false,
       accent: 'border-amber-500',
@@ -46,8 +88,8 @@ export default function HospitalAdminDashboardPage() {
     },
     {
       label: t('hospital.procuredValue'),
-      value: '1,850,000 RWF',
-      statusText: '12% budget utilization',
+      value: loading ? '—' : (apiStats ? `${apiStats.monthlyRevenue.toLocaleString()} RWF` : '—'),
+      statusText: apiStats ? `${apiStats.totalRevenue.toLocaleString()} RWF total` : '—',
       statusColor: 'text-emerald-600',
       up: true,
       accent: 'border-emerald-500',
@@ -58,9 +100,9 @@ export default function HospitalAdminDashboardPage() {
     },
     {
       label: t('hospital.lowStockExpiry'),
-      value: 7,
+      value: loading ? '—' : (lowStockCount ?? '—'),
       statusText: t('hospital.requiresImmediateAttention'),
-      statusColor: 'text-red-500',
+      statusColor: lowStockCount && lowStockCount > 0 ? 'text-red-500' : 'text-emerald-600',
       up: false,
       accent: 'border-red-500',
       iconBg: 'bg-red-100',
@@ -70,37 +112,6 @@ export default function HospitalAdminDashboardPage() {
     },
   ];
 
-  const chartData = [
-    { label: 'Dec', value: 420 },
-    { label: 'Jan', value: 620 },
-    { label: 'Feb', value: 520 },
-    { label: 'Mar', value: 760 },
-    { label: 'Apr', value: 890 },
-    { label: 'May', value: 940 },
-  ];
-
-  const activityFeed = [
-    {
-      title: 'New appointment scheduled for Kevine Mugisha under Pediatrics.',
-      time: '10 mins ago',
-      color: 'bg-sky-100 text-sky-600',
-    },
-    {
-      title: 'Low stock warning: Amoxicillin 500mg level dropped below threshold limit.',
-      time: '1 hour ago',
-      color: 'bg-amber-100 text-amber-600',
-    },
-    {
-      title: 'Procurement request PR-6644 marked as delivered. Stock levels updated.',
-      time: '3 hours ago',
-      color: 'bg-emerald-100 text-emerald-600',
-    },
-    {
-      title: 'Item Insulin Glargine Vials expired on 2026-05-05.',
-      time: '1 day ago',
-      color: 'bg-red-100 text-red-600',
-    },
-  ];
 
   return (
     <div className="space-y-6">
@@ -184,31 +195,26 @@ export default function HospitalAdminDashboardPage() {
           </div>
 
           <div className="h-[300px]">
-            <ResponsiveContainer width="98%" height="100%">
-              <LineChart data={chartData}>
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="label" axisLine={false} tickLine={false} />
-                <YAxis axisLine={false} tickLine={false} />
-                <Line type="monotone" dataKey="value" dot={false} />
-              </LineChart>
-            </ResponsiveContainer>
+            {!loading && chartData.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-sm text-gray-400">No revenue data available</div>
+            ) : (
+              <ResponsiveContainer width="98%" height="100%">
+                <LineChart data={chartData}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="label" axisLine={false} tickLine={false} />
+                  <YAxis axisLine={false} tickLine={false} />
+                  <Tooltip formatter={(v) => [`${(v as number).toLocaleString()} RWF`, 'Revenue']} />
+                  <Line type="monotone" dataKey="value" dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
           </div>
         </div>
 
         <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6">
           <h2 className="text-lg font-semibold text-slate-900 mb-4">{t('hospital.recentActivity')}</h2>
-          <div className="space-y-5">
-            {activityFeed.map((item) => (
-              <div key={item.title} className="flex gap-4">
-                <div className={`mt-1 h-10 w-10 rounded-2xl flex items-center justify-center ${item.color}`}>
-                  <span className="h-2.5 w-2.5 rounded-full bg-white" />
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-slate-900">{item.title}</p>
-                  <p className="text-xs text-slate-500 mt-1">{item.time}</p>
-                </div>
-              </div>
-            ))}
+          <div className="flex items-center justify-center h-32 text-sm text-gray-400">
+            No recent activity
           </div>
         </div>
       </div>

--- a/src/app/hospital/admin/departments/page.tsx
+++ b/src/app/hospital/admin/departments/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Stethoscope,
   Microscope,
@@ -18,64 +18,69 @@ import {
   Search,
   type LucideIcon,
 } from 'lucide-react';
+import { useHospitalId } from '@/lib/hospital';
+import api from '@/lib/api';
 
 const NAVY = '#1E3A5F';
+const DEPT_COLORS = ['#16A34A', '#7C3AED', '#2563EB', '#EA580C', '#0891B2', '#D97706', '#9333EA', '#0F766E'];
+const DEPT_ICONS: LucideIcon[] = [Stethoscope, Microscope, HeartHandshake, Briefcase, Building2, FlaskConical, HeartPulse, Truck];
 
 interface ServiceRow { icon: LucideIcon; label: string; value: string; }
 interface ServiceGroup { title: string; color: string; icon: LucideIcon; rows: ServiceRow[]; }
 
-const SERVICE_GROUPS: ServiceGroup[] = [
-  {
-    title: 'Clinical Services', color: '#16A34A', icon: Stethoscope,
-    rows: [
-      { icon: Building2, label: 'Departments', value: '16' },
-      { icon: Users,     label: 'Staff',       value: '250 Doctors' },
-      { icon: Activity,  label: 'Status',      value: 'High Activity' },
-    ],
-  },
-  {
-    title: 'Diagnostic Services', color: '#7C3AED', icon: Microscope,
-    rows: [
-      { icon: Building2,    label: 'Departments',    value: '8' },
-      { icon: FlaskConical, label: 'Tests Today',    value: '130' },
-      { icon: Clock,        label: 'Avg Turnaround', value: '1.4 Hrs' },
-    ],
-  },
-  {
-    title: 'Patient Support Services', color: '#2563EB', icon: HeartHandshake,
-    rows: [
-      { icon: Building2, label: 'Departments',          value: '10' },
-      { icon: HeartPulse, label: 'Active Cases',        value: '67' },
-      { icon: Truck,     label: 'Ambulance Trips Today', value: '12' },
-    ],
-  },
-  {
-    title: 'Administrative & Operations', color: '#EA580C', icon: Briefcase,
-    rows: [
-      { icon: Building2,  label: 'Departments',      value: '12' },
-      { icon: Users,      label: 'Staff',            value: '35 Employees' },
-      { icon: DollarSign, label: "Today's billing",  value: 'Rwf 1,250,000' },
-    ],
-  },
-];
-
 interface Employee { name: string; department: string; phone: string; available: boolean; }
 
-const EMPLOYEES: Employee[] = [
-  { name: 'Ella Mutesi',  department: 'Clinical Services',         phone: '+250784266000', available: true  },
-  { name: 'Kelly Butera', department: 'Patient Support Services',  phone: '+250788013456', available: true  },
-  { name: 'Mary Kagabo',  department: 'Administrative & Operations', phone: '+250783000876', available: false },
-  { name: 'Howard Magaju',department: 'Diagnostic Services',       phone: '+250788456521', available: false },
-];
-
 export default function HospitalAdminDepartmentsPage() {
-  const [search, setSearch] = useState('');
-  const [dept, setDept] = useState('All');
+  const hospitalId = useHospitalId();
+  const [search, setSearch]             = useState('');
+  const [dept, setDept]                 = useState('All');
   const [availability, setAvailability] = useState('All');
+  const [serviceGroups, setServiceGroups] = useState<ServiceGroup[]>([]);
+  const [employees, setEmployees]       = useState<Employee[]>([]);
+  const [loading, setLoading]           = useState(true);
 
-  const departments = ['All', ...SERVICE_GROUPS.map(g => g.title)];
+  useEffect(() => {
+    if (!hospitalId) { setLoading(false); return; }
+    api.get(`/hospitals/${hospitalId}/doctors`)
+      .then(res => {
+        const doctors: any[] = Array.isArray(res.data) ? res.data : [];
 
-  const filtered = EMPLOYEES.filter(e => {
+        const mapped: Employee[] = doctors.map(doc => ({
+          name: doc.user?.hospitalStaff
+            ? `${doc.user.hospitalStaff.firstName} ${doc.user.hospitalStaff.lastName}`.trim()
+            : (doc.user?.email ?? 'Unknown'),
+          department: doc.specialization ?? 'General',
+          phone: doc.user?.hospitalStaff?.phone ?? '—',
+          available: !!doc.isAvailable,
+        }));
+        if (mapped.length) setEmployees(mapped);
+
+        const bySpec = doctors.reduce((acc: Record<string, any[]>, doc) => {
+          const key = doc.specialization ?? 'General';
+          if (!acc[key]) acc[key] = [];
+          acc[key].push(doc);
+          return acc;
+        }, {});
+
+        const derived: ServiceGroup[] = Object.entries(bySpec).map(([spec, docs], i) => ({
+          title: spec,
+          color: DEPT_COLORS[i % DEPT_COLORS.length],
+          icon: DEPT_ICONS[i % DEPT_ICONS.length],
+          rows: [
+            { icon: Users,     label: 'Doctors',   value: docs.length.toString() },
+            { icon: Activity,  label: 'Available', value: docs.filter((d: any) => d.isAvailable).length.toString() },
+            { icon: Building2, label: 'Status',    value: docs.some((d: any) => d.isAvailable) ? 'Active' : 'Inactive' },
+          ],
+        }));
+        if (derived.length) setServiceGroups(derived);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [hospitalId]);
+
+  const departments = ['All', ...serviceGroups.map(g => g.title)];
+
+  const filtered = employees.filter(e => {
     if (search.trim() && !e.name.toLowerCase().includes(search.trim().toLowerCase())) return false;
     if (dept !== 'All' && e.department !== dept) return false;
     if (availability === 'Available' && !e.available) return false;
@@ -105,8 +110,13 @@ export default function HospitalAdminDepartmentsPage() {
       </div>
 
       {/* Service group cards */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-gray-400">Loading departments…</div>
+      ) : serviceGroups.length === 0 ? (
+        <div className="flex items-center justify-center py-12 text-sm text-gray-400">No departments found.</div>
+      ) : (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        {SERVICE_GROUPS.map(group => {
+        {serviceGroups.map(group => {
           const Icon = group.icon;
           return (
             <div key={group.title} className="bg-white rounded-2xl border shadow-sm p-6" style={{ borderColor: `${group.color}25` }}>
@@ -135,6 +145,7 @@ export default function HospitalAdminDepartmentsPage() {
           );
         })}
       </div>
+      )}
 
       {/* Employee Directory */}
       <div>
@@ -186,8 +197,8 @@ export default function HospitalAdminDepartmentsPage() {
               <tbody className="divide-y divide-gray-50 text-sm">
                 {filtered.length === 0 ? (
                   <tr><td colSpan={4} className="px-6 py-10 text-center text-gray-400 font-medium">No employees found.</td></tr>
-                ) : filtered.map(emp => (
-                  <tr key={emp.name} className="hover:bg-gray-50/70 transition-colors">
+                ) : filtered.map((emp, idx) => (
+                  <tr key={`${emp.name}-${idx}`} className="hover:bg-gray-50/70 transition-colors">
                     <td className="px-6 py-4 font-bold text-gray-900">{emp.name}</td>
                     <td className="px-6 py-4 text-gray-600">{emp.department}</td>
                     <td className="px-6 py-4 text-gray-600">{emp.phone}</td>

--- a/src/app/hospital/admin/departments/page.tsx
+++ b/src/app/hospital/admin/departments/page.tsx
@@ -38,6 +38,7 @@ export default function HospitalAdminDepartmentsPage() {
   const [serviceGroups, setServiceGroups] = useState<ServiceGroup[]>([]);
   const [employees, setEmployees]       = useState<Employee[]>([]);
   const [loading, setLoading]           = useState(true);
+  const [error, setError]               = useState(false);
 
   useEffect(() => {
     if (!hospitalId) { setLoading(false); return; }
@@ -74,7 +75,7 @@ export default function HospitalAdminDepartmentsPage() {
         }));
         if (derived.length) setServiceGroups(derived);
       })
-      .catch(() => {})
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, [hospitalId]);
 
@@ -99,7 +100,11 @@ export default function HospitalAdminDepartmentsPage() {
               Access and manage doctors, nurses and hospital staff in one place.
             </p>
           </div>
-          <button className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity" style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}>
+          <button
+            disabled
+            className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-white opacity-50 cursor-not-allowed"
+            style={{ background: 'linear-gradient(to right, #0284C7, #38BDF8)' }}
+          >
             <Stethoscope size={15} />
             Select Department
           </button>
@@ -108,6 +113,12 @@ export default function HospitalAdminDepartmentsPage() {
           <GitFork size={72} className="rotate-180" />
         </div>
       </div>
+
+      {error && (
+        <div className="rounded-xl bg-red-50 border border-red-200 px-5 py-3 text-sm text-red-700">
+          Could not load department data — check your connection and refresh.
+        </div>
+      )}
 
       {/* Service group cards */}
       {loading ? (

--- a/src/app/hospital/admin/finance/page.tsx
+++ b/src/app/hospital/admin/finance/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   BanknotesIcon,
   ClockIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 
-import RevenueChart from '@/components/hospital/finance/RevenueChart';
+import RevenueChart, {
+  type RevenueChartPeriod,
+  type RevenueDataPoint,
+} from '@/components/hospital/finance/RevenueChart';
 import PaymentBreakdownChart from '@/components/hospital/finance/PaymentBreakdownChart';
 import InvoiceTable from '@/components/hospital/finance/InvoiceTable';
 import RefundTable from '@/components/hospital/finance/RefundTable';
@@ -19,15 +22,20 @@ import type { Invoice } from '@/types/hospital';
 
 export default function HospitalAdminFinancePage() {
   const hospitalId = useHospitalId();
-  const [invoices, setInvoices] = useState<Invoice[]>([]);
-  const [loading, setLoading]   = useState(true);
-  const [error, setError]       = useState(false);
+  const [invoices, setInvoices]           = useState<Invoice[]>([]);
+  const [loading, setLoading]             = useState(true);
+  const [error, setError]                 = useState(false);
+  const [weeklyRevData, setWeeklyRevData] = useState<RevenueDataPoint[]>([]);
+  const [revPeriod, setRevPeriod]         = useState<RevenueChartPeriod>('Weekly');
 
   useEffect(() => {
     if (!hospitalId) { setLoading(false); return; }
-    api.get(`/hospitals/${hospitalId}/invoices?limit=100`)
-      .then(res => {
-        const raw: any[] = res.data?.data ?? [];
+    Promise.allSettled([
+      api.get(`/hospitals/${hospitalId}/invoices?limit=100`),
+      api.get(`/hospitals/${hospitalId}/dashboard/weekly-revenue`),
+    ]).then(([invoicesRes, weeklyRes]) => {
+      if (invoicesRes.status === 'fulfilled') {
+        const raw: any[] = invoicesRes.value.data?.data ?? [];
         setInvoices(raw.map(item => ({
           id: item.id,
           patientName: `${item.patient?.firstName ?? ''} ${item.patient?.lastName ?? ''}`.trim() || 'Unknown',
@@ -36,10 +44,60 @@ export default function HospitalAdminFinancePage() {
           dueDate: item.issuedAt,
           createdAt: item.issuedAt,
         })));
-      })
-      .catch(() => setError(true))
-      .finally(() => setLoading(false));
+      } else {
+        setError(true);
+      }
+      if (weeklyRes.status === 'fulfilled') {
+        const rows: { label: string; revenue: number }[] = Array.isArray(weeklyRes.value.data)
+          ? weeklyRes.value.data
+          : [];
+        setWeeklyRevData(rows.map(r => ({ label: r.label, revenue: r.revenue })));
+      }
+    }).finally(() => setLoading(false));
   }, [hospitalId]);
+
+  const dailyRevData = useMemo<RevenueDataPoint[]>(() => {
+    const today = new Date();
+    const buckets = Array.from({ length: 30 }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - (29 - i));
+      return {
+        key: d.toISOString().substring(0, 10),
+        label: d.toLocaleDateString('en', { month: 'short', day: 'numeric' }),
+        revenue: 0,
+      };
+    });
+    const bucketMap = new Map(buckets.map(b => [b.key, b]));
+    invoices.forEach(inv => {
+      if (!inv.dueDate) return;
+      const bucket = bucketMap.get(inv.dueDate.substring(0, 10));
+      if (bucket) bucket.revenue += inv.totalAmount;
+    });
+    return buckets.map(({ label, revenue }) => ({ label, revenue }));
+  }, [invoices]);
+
+  const monthlyRevData = useMemo<RevenueDataPoint[]>(() => {
+    const map = new Map<string, RevenueDataPoint>();
+    invoices.forEach(inv => {
+      if (!inv.dueDate) return;
+      const d = new Date(inv.dueDate);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      const label = d.toLocaleDateString('en', { month: 'short', year: '2-digit' });
+      const existing = map.get(key);
+      if (existing) {
+        existing.revenue += inv.totalAmount;
+      } else {
+        map.set(key, { label, revenue: inv.totalAmount });
+      }
+    });
+    return [...map.values()];
+  }, [invoices]);
+
+  const revData: Record<RevenueChartPeriod, RevenueDataPoint[]> = {
+    Daily:   dailyRevData,
+    Weekly:  weeklyRevData,
+    Monthly: monthlyRevData,
+  };
 
   const totalRevenue     = invoices.reduce((s, i) => s + i.totalAmount, 0);
   const unpaid           = invoices.filter(i => i.status === 'UNPAID');
@@ -104,7 +162,8 @@ export default function HospitalAdminFinancePage() {
       {/* Charts row */}
       <div className="grid grid-cols-1 xl:grid-cols-[2fr_1fr] gap-5">
         <RevenueChart
-          data={[]}
+          data={revData[revPeriod]}
+          onPeriodChange={setRevPeriod}
           title="Revenue Overview"
           showExpenses={false}
           defaultPeriod="Weekly"

--- a/src/app/hospital/admin/finance/page.tsx
+++ b/src/app/hospital/admin/finance/page.tsx
@@ -21,9 +21,10 @@ export default function HospitalAdminFinancePage() {
   const hospitalId = useHospitalId();
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(false);
 
   useEffect(() => {
-    if (!hospitalId) return;
+    if (!hospitalId) { setLoading(false); return; }
     api.get(`/hospitals/${hospitalId}/invoices?limit=100`)
       .then(res => {
         const raw: any[] = res.data?.data ?? [];
@@ -36,19 +37,19 @@ export default function HospitalAdminFinancePage() {
           createdAt: item.issuedAt,
         })));
       })
-      .catch(() => {})
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, [hospitalId]);
 
-  const totalRevenue   = invoices.reduce((s, i) => s + i.totalAmount, 0);
-  const unpaid         = invoices.filter(i => i.status === 'UNPAID');
+  const totalRevenue     = invoices.reduce((s, i) => s + i.totalAmount, 0);
+  const unpaid           = invoices.filter(i => i.status === 'UNPAID');
   const insurancePending = invoices.filter(i => i.status === 'INSURANCE_PENDING');
 
   const FINANCE_KPIS = [
-    { label: 'Total Revenues',   value: loading ? '—' : (invoices.length ? `RWF ${totalRevenue.toLocaleString()}` : '—'),                                             sub: loading ? '—' : (invoices.length ? `${invoices.length} invoices total` : '—'),    trend: true,  icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
-    { label: 'Pending Payments', value: loading ? '—' : (invoices.length ? `RWF ${unpaid.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'),           sub: loading ? '—' : (invoices.length ? `${unpaid.length} Invoices` : '—'),             trend: false, icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100',     iconColor: 'text-red-500'     },
-    { label: 'Overdue Payments', value: loading ? '—' : (invoices.length ? `RWF ${insurancePending.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'), sub: loading ? '—' : (invoices.length ? `${insurancePending.length} Invoices` : '—'),    trend: false, icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
-    { label: 'Refunds',          value: '—',                                                                                                                   sub: '—',                                                                               trend: false, icon: <ClockIcon className="w-5 h-5" />,               accentColor: 'bg-purple-100',  iconColor: 'text-purple-600'  },
+    { label: 'Total Revenues',     value: loading ? '—' : (invoices.length ? `RWF ${totalRevenue.toLocaleString()}` : '—'),                                               sub: loading ? '—' : (invoices.length ? `${invoices.length} invoices total` : '—'),       trend: true,  icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
+    { label: 'Pending Payments',   value: loading ? '—' : (invoices.length ? `RWF ${unpaid.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'),             sub: loading ? '—' : (invoices.length ? `${unpaid.length} Invoices` : '—'),                trend: false, icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100',     iconColor: 'text-red-500'     },
+    { label: 'Insurance Pending',  value: loading ? '—' : (invoices.length ? `RWF ${insurancePending.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'),   sub: loading ? '—' : (invoices.length ? `${insurancePending.length} Invoices` : '—'),     trend: false, icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
+    { label: 'Refunds',            value: '—',                                                                                                                     sub: '—',                                                                                 trend: false, icon: <ClockIcon className="w-5 h-5" />,               accentColor: 'bg-purple-100',  iconColor: 'text-purple-600'  },
   ];
 
   return (
@@ -72,6 +73,12 @@ export default function HospitalAdminFinancePage() {
           <polyline points="8,30 34,14 60,22 86,6 112,18" stroke="#2D9B8A" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" fill="none" />
         </svg>
       </div>
+
+      {error && (
+        <div className="rounded-xl bg-red-50 border border-red-200 px-5 py-3 text-sm text-red-700">
+          Could not load finance data — check your connection and refresh.
+        </div>
+      )}
 
       {/* KPI cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">

--- a/src/app/hospital/admin/finance/page.tsx
+++ b/src/app/hospital/admin/finance/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import {
   BanknotesIcon,
   ClockIcon,
@@ -11,40 +12,45 @@ import PaymentBreakdownChart from '@/components/hospital/finance/PaymentBreakdow
 import InvoiceTable from '@/components/hospital/finance/InvoiceTable';
 import RefundTable from '@/components/hospital/finance/RefundTable';
 
-import { MOCK_INVOICES } from '@/mock/hospital/finance';
-import type { PaymentBreakdownItem } from '@/components/hospital/finance/PaymentBreakdownChart';
-import type { RefundItem } from '@/components/hospital/finance/RefundTable';
+import { useHospitalId } from '@/lib/hospital';
+import api from '@/lib/api';
+import type { Invoice } from '@/types/hospital';
 
-const REVENUE_CHART_DATA = [
-  { label: 'JAN', revenue: 3_800_000, expenses: 2_200_000 },
-  { label: 'FEB', revenue: 4_500_000, expenses: 2_900_000 },
-  { label: 'MAR', revenue: 3_200_000, expenses: 2_400_000 },
-  { label: 'APR', revenue: 2_900_000, expenses: 2_100_000 },
-  { label: 'MAY', revenue: 4_100_000, expenses: 2_700_000 },
-  { label: 'JUN', revenue: 3_600_000, expenses: 2_500_000 },
-  { label: 'JUL', revenue: 4_800_000, expenses: 3_100_000 },
-];
-
-const PAYMENT_BREAKDOWN: PaymentBreakdownItem[] = [
-  { name: 'Mobile Money', value: 1_530_769, color: '#1E4D8C' },
-  { name: 'Cash',         value: 2_037_670, color: '#93c5fd' },
-];
-
-const REFUNDS: RefundItem[] = [
-  { id: 'RF-008', amount: 1_000,  status: 'APPROVED', date: '2023-05-21' },
-  { id: 'RF-007', amount: 17_000, status: 'REJECTED', date: '2023-05-19' },
-  { id: 'RF-006', amount: 67_090, status: 'PENDING',  date: '2023-05-10' },
-  { id: 'RF-005', amount: 34_100, status: 'REJECTED', date: '2023-05-18' },
-];
-
-const FINANCE_KPIS = [
-  { label: 'Total Revenues',   value: 'RWF 123,456', sub: '+12.5% from last week', trend: true,  icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
-  { label: 'Pending Payments', value: 'RWF 54,321',  sub: '18 Invoices',           trend: false, icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100',     iconColor: 'text-red-500'     },
-  { label: 'Overdue Payments', value: 'RWF 3,456',   sub: '9 Invoices',            trend: false, icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
-  { label: 'Refunds',          value: 'RWF 350,000', sub: '+24% from last week',   trend: true,  icon: <ClockIcon className="w-5 h-5" />,               accentColor: 'bg-purple-100',  iconColor: 'text-purple-600'  },
-];
 
 export default function HospitalAdminFinancePage() {
+  const hospitalId = useHospitalId();
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [loading, setLoading]   = useState(true);
+
+  useEffect(() => {
+    if (!hospitalId) return;
+    api.get(`/hospitals/${hospitalId}/invoices?limit=100`)
+      .then(res => {
+        const raw: any[] = res.data?.data ?? [];
+        setInvoices(raw.map(item => ({
+          id: item.id,
+          patientName: `${item.patient?.firstName ?? ''} ${item.patient?.lastName ?? ''}`.trim() || 'Unknown',
+          totalAmount: item.totalAmount,
+          status: item.paymentStatus,
+          dueDate: item.issuedAt,
+          createdAt: item.issuedAt,
+        })));
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [hospitalId]);
+
+  const totalRevenue   = invoices.reduce((s, i) => s + i.totalAmount, 0);
+  const unpaid         = invoices.filter(i => i.status === 'UNPAID');
+  const insurancePending = invoices.filter(i => i.status === 'INSURANCE_PENDING');
+
+  const FINANCE_KPIS = [
+    { label: 'Total Revenues',   value: loading ? '—' : (invoices.length ? `RWF ${totalRevenue.toLocaleString()}` : '—'),                                             sub: loading ? '—' : (invoices.length ? `${invoices.length} invoices total` : '—'),    trend: true,  icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-blue-100',    iconColor: 'text-blue-600'    },
+    { label: 'Pending Payments', value: loading ? '—' : (invoices.length ? `RWF ${unpaid.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'),           sub: loading ? '—' : (invoices.length ? `${unpaid.length} Invoices` : '—'),             trend: false, icon: <ExclamationTriangleIcon className="w-5 h-5" />, accentColor: 'bg-red-100',     iconColor: 'text-red-500'     },
+    { label: 'Overdue Payments', value: loading ? '—' : (invoices.length ? `RWF ${insurancePending.reduce((s, i) => s + i.totalAmount, 0).toLocaleString()}` : '—'), sub: loading ? '—' : (invoices.length ? `${insurancePending.length} Invoices` : '—'),    trend: false, icon: <BanknotesIcon className="w-5 h-5" />,           accentColor: 'bg-emerald-100', iconColor: 'text-emerald-600' },
+    { label: 'Refunds',          value: '—',                                                                                                                   sub: '—',                                                                               trend: false, icon: <ClockIcon className="w-5 h-5" />,               accentColor: 'bg-purple-100',  iconColor: 'text-purple-600'  },
+  ];
+
   return (
     <div className="space-y-6">
 
@@ -91,14 +97,14 @@ export default function HospitalAdminFinancePage() {
       {/* Charts row */}
       <div className="grid grid-cols-1 xl:grid-cols-[2fr_1fr] gap-5">
         <RevenueChart
-          data={REVENUE_CHART_DATA}
+          data={[]}
           title="Revenue Overview"
           showExpenses={false}
           defaultPeriod="Weekly"
           variant="bar"
         />
         <PaymentBreakdownChart
-          data={PAYMENT_BREAKDOWN}
+          data={[]}
           title="Payment Method Breakdown"
         />
       </div>
@@ -106,11 +112,11 @@ export default function HospitalAdminFinancePage() {
       {/* Invoice table + Refund panel */}
       <div className="grid grid-cols-1 xl:grid-cols-[2fr_1fr] gap-5">
         <InvoiceTable
-          invoices={MOCK_INVOICES}
+          invoices={invoices}
           onExport={() => console.log('export')}
         />
         <RefundTable
-          refunds={REFUNDS}
+          refunds={[]}
           onViewAll={() => console.log('view all refunds')}
         />
       </div>

--- a/src/app/hospital/admin/inventory/page.tsx
+++ b/src/app/hospital/admin/inventory/page.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Hexagon, AlertTriangle, ClipboardList, Search } from 'lucide-react';
+import { useHospitalId } from '@/lib/hospital';
+import api from '@/lib/api';
 
 type Category = 'Drug' | 'Supply' | 'Equipment';
 type Stock = 'IN_STOCK' | 'LOW_STOCK';
 type Alert = 'SAFE' | 'EXPIRING' | 'EXPIRED' | null;
 
 interface InventoryItem {
+  id: string;
+  drugId?: string;
   name: string;
   category: Category;
   quantity: number;
@@ -18,15 +22,16 @@ interface InventoryItem {
   alertLabel?: string;
 }
 
-const ITEMS: InventoryItem[] = [
-  { name: 'Amoxicillin 500mg',      category: 'Drug',      quantity: 45,  reorder: 100, expiry: '2026-09-12', stock: 'LOW_STOCK', alert: 'SAFE' },
-  { name: 'Ibuprofen 400mg',        category: 'Drug',      quantity: 210, reorder: 50,  expiry: '2027-02-15', stock: 'IN_STOCK',  alert: 'SAFE' },
-  { name: 'Lisinopril 10mg',        category: 'Drug',      quantity: 12,  reorder: 20,  expiry: '2026-06-25', stock: 'LOW_STOCK', alert: 'EXPIRING', alertLabel: 'Expiring (35d)' },
-  { name: 'Surgical Sterile Gloves',category: 'Supply',    quantity: 850, reorder: 200, expiry: '2029-10-30', stock: 'IN_STOCK',  alert: 'SAFE' },
-  { name: 'N95 Respirator Masks',   category: 'Supply',    quantity: 80,  reorder: 150, expiry: '2026-04-10', stock: 'LOW_STOCK', alert: 'EXPIRED' },
-  { name: 'ECG Patient Monitor',    category: 'Equipment', quantity: 6,   reorder: 2,   expiry: null,         stock: 'IN_STOCK',  alert: null },
-  { name: 'Automated Defibrillator',category: 'Equipment', quantity: 1,   reorder: 2,   expiry: null,         stock: 'LOW_STOCK', alert: null },
-];
+function computeAlert(expiryDate: string | null): { alert: Alert; alertLabel?: string } {
+  if (!expiryDate) return { alert: null };
+  const now = Date.now();
+  const exp = new Date(expiryDate).getTime();
+  if (exp < now) return { alert: 'EXPIRED' };
+  const daysLeft = Math.ceil((exp - now) / 86_400_000);
+  if (daysLeft <= 60) return { alert: 'EXPIRING', alertLabel: `Expiring (${daysLeft}d)` };
+  return { alert: 'SAFE' };
+}
+
 
 const MODE_CARDS = [
   { id: 'stock',       title: 'Hospital Stock',  desc: 'Track current drug supplies, equipment, and medical inventory levels.', icon: Hexagon,       color: '#2563EB' },
@@ -53,11 +58,60 @@ const ALERT_STYLE: Record<Exclude<Alert, null>, { bg: string; color: string; lab
 };
 
 export default function HospitalAdminInventoryPage() {
+  const hospitalId = useHospitalId();
   const [activeMode, setActiveMode] = useState('stock');
-  const [tab, setTab] = useState('ALL');
-  const [search, setSearch] = useState('');
+  const [tab, setTab]               = useState('ALL');
+  const [search, setSearch]         = useState('');
+  const [items, setItems]           = useState<InventoryItem[]>([]);
+  const [loadingItems, setLoadingItems] = useState(true);
+  const [editingId, setEditingId]   = useState<string | null>(null);
+  const [editQty, setEditQty]       = useState<number>(0);
+  const [saving, setSaving]         = useState(false);
 
-  const filtered = ITEMS.filter(i => {
+  useEffect(() => {
+    if (!hospitalId) { setLoadingItems(false); return; }
+    api.get(`/hospitals/${hospitalId}/drug-stock`)
+      .then(res => {
+        const raw: any[] = Array.isArray(res.data) ? res.data : [];
+        const mapped: InventoryItem[] = raw.map(item => {
+          const { alert, alertLabel } = computeAlert(item.expiryDate);
+          return {
+            id:       item.id,
+            drugId:   item.drugId,
+            name:     item.drug?.brandName ?? 'Unknown',
+            category: 'Drug' as Category,
+            quantity: item.quantity,
+            reorder:  item.reorderLevel,
+            expiry:   item.expiryDate ? item.expiryDate.substring(0, 10) : null,
+            stock:    item.lowStockAlert ? 'LOW_STOCK' : 'IN_STOCK',
+            alert,
+            alertLabel,
+          };
+        });
+        setItems(mapped);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingItems(false));
+  }, [hospitalId]);
+
+  const handleSaveQty = async (item: InventoryItem) => {
+    if (!hospitalId || !item.drugId) return;
+    setSaving(true);
+    try {
+      await api.patch(`/hospitals/${hospitalId}/drug-stock/${item.drugId}`, { qtyOnHand: editQty });
+      setItems(prev => prev.map(i =>
+        i.id === item.id
+          ? { ...i, quantity: editQty, stock: editQty <= i.reorder ? 'LOW_STOCK' : 'IN_STOCK' }
+          : i
+      ));
+      setEditingId(null);
+    } catch {
+      // silently fail — toast can be added later
+    }
+    setSaving(false);
+  };
+
+  const filtered = items.filter(i => {
     if (tab !== 'ALL' && i.category !== tab) return false;
     if (search.trim() && !i.name.toLowerCase().includes(search.trim().toLowerCase())) return false;
     return true;
@@ -134,13 +188,15 @@ export default function HospitalAdminInventoryPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50 text-sm">
-              {filtered.length === 0 ? (
+              {loadingItems ? (
+                <tr><td colSpan={7} className="px-6 py-12 text-center text-gray-400 font-medium">Loading inventory…</td></tr>
+              ) : filtered.length === 0 ? (
                 <tr><td colSpan={7} className="px-6 py-12 text-center text-gray-400 font-medium">No items found.</td></tr>
               ) : filtered.map(item => {
                 const stock = STOCK_STYLE[item.stock];
                 const alert = item.alert ? ALERT_STYLE[item.alert] : null;
                 return (
-                  <tr key={item.name} className="hover:bg-gray-50/70 transition-colors">
+                  <tr key={item.id} className="hover:bg-gray-50/70 transition-colors">
                     <td className="px-6 py-4 font-bold text-gray-900">{item.name}</td>
                     <td className="px-6 py-4 text-gray-500">{item.category}</td>
                     <td className="px-6 py-4 font-semibold text-gray-800">{item.quantity} units</td>
@@ -160,9 +216,37 @@ export default function HospitalAdminInventoryPage() {
                       </div>
                     </td>
                     <td className="px-6 py-4 text-right">
-                      <button className="px-3 py-2 text-xs font-semibold text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap">
-                        Request Stock
-                      </button>
+                      {editingId === item.id ? (
+                        <div className="flex items-center gap-1.5 justify-end">
+                          <input
+                            type="number"
+                            min={0}
+                            value={editQty}
+                            onChange={e => setEditQty(Number(e.target.value))}
+                            className="w-20 px-2 py-1 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-blue-500"
+                          />
+                          <button
+                            onClick={() => handleSaveQty(item)}
+                            disabled={saving}
+                            className="px-2 py-1 text-xs font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                          >
+                            {saving ? '…' : 'Save'}
+                          </button>
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="px-2 py-1 text-xs font-semibold text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50"
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => { setEditingId(item.id); setEditQty(item.quantity); }}
+                          className="px-3 py-2 text-xs font-semibold text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap"
+                        >
+                          Request Stock
+                        </button>
+                      )}
                     </td>
                   </tr>
                 );

--- a/src/app/hospital/admin/inventory/page.tsx
+++ b/src/app/hospital/admin/inventory/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Hexagon, AlertTriangle, ClipboardList, Search } from 'lucide-react';
 import { useHospitalId } from '@/lib/hospital';
 import api from '@/lib/api';
+import toast from 'react-hot-toast';
 
 type Category = 'Drug' | 'Supply' | 'Equipment';
 type Stock = 'IN_STOCK' | 'LOW_STOCK';
@@ -106,12 +107,16 @@ export default function HospitalAdminInventoryPage() {
       ));
       setEditingId(null);
     } catch {
-      // silently fail — toast can be added later
+      toast.error('Failed to update stock — please try again.');
     }
     setSaving(false);
   };
 
-  const filtered = items.filter(i => {
+  const modeFiltered = activeMode === 'alerts'
+    ? items.filter(i => i.alert !== null)
+    : items;
+
+  const filtered = modeFiltered.filter(i => {
     if (tab !== 'ALL' && i.category !== tab) return false;
     if (search.trim() && !i.name.toLowerCase().includes(search.trim().toLowerCase())) return false;
     return true;
@@ -145,7 +150,14 @@ export default function HospitalAdminInventoryPage() {
         })}
       </div>
 
+      {activeMode === 'procurement' && (
+        <div className="flex items-center justify-center py-16 text-sm text-gray-400 bg-white rounded-2xl border border-gray-100 shadow-sm">
+          Procurement log is not yet available — no backend endpoint exists for this feature.
+        </div>
+      )}
+
       {/* Tabs + search */}
+      {activeMode !== 'procurement' && (
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
           {TABS.map(tb => (
@@ -171,9 +183,10 @@ export default function HospitalAdminInventoryPage() {
           />
         </div>
       </div>
+      )}
 
       {/* Table */}
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+      {activeMode !== 'procurement' && <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-left border-collapse min-w-[880px]">
             <thead>
@@ -254,7 +267,7 @@ export default function HospitalAdminInventoryPage() {
             </tbody>
           </table>
         </div>
-      </div>
+      </div>}
     </div>
   );
 }

--- a/src/docs/HOSPITAL_ADMIN_BACKEND_CONTRACT.md
+++ b/src/docs/HOSPITAL_ADMIN_BACKEND_CONTRACT.md
@@ -1,0 +1,297 @@
+# Hospital Admin Portal — Backend Contract & Gaps
+
+> **Scope:** `admin/dashboard`, `admin/departments`, `admin/finance`, `admin/inventory`
+> **Source-verified against:** `back-end/src/hospitals/hospitals.controller.ts`, `hospitals.service.ts`, `invoices/invoices.service.ts`
+> **Last updated:** 2026-06-29
+> **See also:** [`HOSPITAL_ADMIN_DASHBOARD_DEPARTMENTS_INTEGRATION.md`](./HOSPITAL_ADMIN_DASHBOARD_DEPARTMENTS_INTEGRATION.md) for the earlier dashboard/departments integration writeup with full fix history.
+
+---
+
+## Legend
+
+| Icon | Meaning |
+|------|---------|
+| ✅ | Endpoint confirmed implemented and reachable |
+| ⚠️ | Endpoint exists but has a known issue (migration, field name mismatch, etc.) |
+| ❌ | Endpoint confirmed missing — frontend cannot call it |
+
+---
+
+## Endpoint contract
+
+### Dashboard — `admin/dashboard`
+
+All three endpoints exist and are implemented. All are restricted to `HOSPITAL_ADMIN` only.
+
+---
+
+#### `GET /hospitals/:id/dashboard/stats` ✅
+
+```ts
+// Response shape (exact field names from hospitals.service.ts::getStats)
+{
+  totalAppointments: {
+    thisMonth: number,   // appointments this calendar month
+    allTime:   number,   // all-time total
+  },
+  appointmentsByStatus: {
+    PENDING:   number,   // backend status SCHEDULED
+    CONFIRMED: number,   // backend statuses ARRIVED | IN_TRIAGE | READY_FOR_DOCTOR (bucketed)
+    COMPLETED: number,
+    CANCELLED: number,   // backend statuses CANCELLED | NO_SHOW (bucketed)
+  },
+  totalRevenue:   number,  // all-time revenue from hospital_invoices
+  monthlyRevenue: number,  // this calendar month
+  totalDoctors:   number,
+  activeDoctors:  number,  // doctors with isAvailable === true
+  totalPatients:  number,  // registered via HospitalPatientRegistration
+}
+```
+
+> ⚠️ **Gap A — Status bucketing:** The backend `AppointmentStatus` enum has 7 values
+> (`SCHEDULED`, `COMPLETED`, `CANCELLED`, `NO_SHOW`, `ARRIVED`, `IN_TRIAGE`,
+> `READY_FOR_DOCTOR`). The response maps these into 4 frontend buckets. If the
+> product requires separate counts for `ARRIVED`, `IN_TRIAGE`, etc., the service
+> needs to return them separately — the current bucketing is a pragmatic choice
+> made during integration, not a product decision.
+
+---
+
+#### `GET /hospitals/:id/dashboard/weekly-revenue` ✅
+
+```ts
+// Response shape — array of 4 items (last 4 calendar weeks, oldest first)
+Array<{
+  label:   string,  // e.g. "Jun 2 – Jun 8"
+  revenue: number,
+}>
+```
+
+---
+
+#### `GET /hospitals/:id/dashboard/daily-appointments` ✅
+
+```ts
+// Response shape — array of 30 items (last 30 days, oldest first)
+Array<{
+  date:  string,  // "YYYY-MM-DD"
+  label: string,  // e.g. "Jun 1"
+  count: number,
+}>
+```
+
+---
+
+#### `GET /hospitals/:id/drug-stock` (dashboard low-stock card) ✅
+
+Used by dashboard as a secondary call to populate the low-stock alert count.
+Full contract under [Inventory](#inventory----admininventory) below.
+
+---
+
+#### ❌ No procurement/spend endpoint
+
+The dashboard mock had a "Procured Value" stat card. There is no `Procurement`
+or `PurchaseOrder` model anywhere in `schema.prisma`, and no endpoint that
+returns procurement spend. **Decision:** show `monthlyRevenue` as the closest
+available substitute. This is a net-new feature, not an integration gap.
+
+---
+
+### Departments — `admin/departments`
+
+#### `GET /hospitals/:id/departments` ⚠️ MIGRATION PENDING
+
+This endpoint **was added to the backend** as part of the dashboard/departments
+integration (see `HOSPITAL_ADMIN_DASHBOARD_DEPARTMENTS_INTEGRATION.md`, Gap 1).
+The controller route and service method both exist. However the endpoint
+**will throw a Postgres "column does not exist" error** until the following
+migration is applied to the database:
+
+```bash
+cd back-end
+npx prisma migrate dev --name add_department_and_dept_head_fields --schema=src/prisma/schema.prisma
+```
+
+Or, if the direct Supabase connection is unavailable, run this SQL manually in
+the Supabase SQL editor then mark the migration resolved:
+
+```sql
+ALTER TABLE "doctors"       ADD COLUMN "isDepartmentHead" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "hospital_staff" ADD COLUMN "department"       TEXT;
+```
+
+```ts
+// Response shape once migration is applied
+Array<{
+  name:        string,   // doctor specialization (e.g. "Cardiology")
+  doctorCount: number,
+  nurseCount:  number,   // requires HospitalStaff.department field (migration)
+  head:        string | null,  // name of doctor with isDepartmentHead === true
+  status:      'ACTIVE' | 'INACTIVE',  // ACTIVE if any doctor in dept has isAvailable === true
+}>
+```
+
+> **Allowed roles:** `SUPER_ADMIN`, `HOSPITAL_ADMIN`, `DOCTOR`, `NURSE`, `RECEPTIONIST`
+>
+> Note: this endpoint does NOT use the private `validateHospitalAccess()` helper
+> (which only allows the hospital's owning admin). It uses the simpler hospital
+> existence check so nurses and doctors can also call it — see Gap B below.
+
+---
+
+### Finance — `admin/finance`
+
+#### `GET /hospitals/:id/invoices` ✅
+
+```
+GET /hospitals/:id/invoices?status=PAID&from=2026-01-01&to=2026-12-31&page=1&limit=10
+```
+
+All query params are optional. Do not send a param if it has no value (e.g. do not
+send `?status=undefined` — omit the key entirely).
+
+```ts
+// Response shape
+{
+  data: Array<{
+    id:            string,
+    hospitalId:    string,
+    patientId:     string,
+    totalAmount:   number,
+    paymentStatus: 'UNPAID' | 'PAID' | 'INSURANCE_PENDING',  // ← field name is paymentStatus, not status
+    issuedAt:      string,   // ISO datetime
+    items:         Array<any>,
+    patient: {
+      firstName: string,
+      lastName:  string,
+      phone:     string,
+    },
+    hospital: {
+      id:      string,
+      name:    string,
+      address: string,
+    },
+    appointment: {
+      date:   string,
+      reason: string,
+    } | null,
+  }>,
+  meta: {
+    total: number,
+    page:  number,
+    limit: number,
+    pages: number,
+  }
+}
+```
+
+> ⚠️ **Gap C — Field name:** the invoice status field on the response object is
+> `paymentStatus`, not `status`. The `InvoiceStatus` type in `src/types/hospital.ts`
+> may need to reflect this. The `?status=` query param is correctly named on the
+> request side — the service maps it to `where.paymentStatus` internally.
+
+> **Default pagination:** page 1, limit 10 (max limit 100). Always check `meta.pages`
+> to know whether to show a next-page button.
+
+---
+
+### Inventory — `admin/inventory`
+
+#### `GET /hospitals/:id/drug-stock` ✅
+
+**Allowed roles:** `HOSPITAL_ADMIN`, `DOCTOR`, `NURSE`, `PHARMACIST`
+
+```ts
+// Response shape — array, ordered by lastUpdated desc
+Array<{
+  id:           string,
+  hospitalId:   string,
+  drugId:       string,
+  quantity:     number,         // current stock level
+  reorderLevel: number,         // threshold that triggers low-stock alert
+  expiryDate:   string | null,  // ISO datetime or null
+  lastUpdated:  string,         // ISO datetime
+  lowStockAlert: boolean,       // computed: quantity <= reorderLevel
+  drug: {
+    brandName:      string,   // ← this is what the task card calls "drugName"
+    genericName:    string,
+    dosageStrength: string,
+    dosageForm:     string,
+  }
+}>
+```
+
+---
+
+#### `PATCH /hospitals/:id/drug-stock/:drugId` ✅
+
+**Allowed roles:** `HOSPITAL_ADMIN`, `PHARMACIST`
+
+> ⚠️ **Gap D — Field name mismatch:** The task card says to send `{ quantity }` in
+> the request body. **This is wrong.** The DTO field is `qtyOnHand`, not `quantity`.
+> The service internally maps `qtyOnHand → quantity` when writing to the database.
+> Sending `{ quantity: 50 }` will be silently ignored (class-validator strips
+> unknown fields); the stock level will not change.
+
+```ts
+// Correct request body
+{
+  qtyOnHand?:    number,  // new stock level (min 0) — send to update quantity
+  reorderLevel?: number,  // new reorder threshold (min 0) — send to update alert level
+}
+
+// Response shape — updated stock item (same shape as GET /drug-stock array item)
+{
+  id:           string,
+  hospitalId:   string,
+  drugId:       string,
+  quantity:     number,   // reflects the new value written from qtyOnHand
+  reorderLevel: number,
+  expiryDate:   string | null,
+  lastUpdated:  string,
+  lowStockAlert: boolean,
+  drug: {
+    brandName:      string,
+    genericName:    string,
+    dosageStrength: string,
+    dosageForm:     string,
+  }
+}
+```
+
+---
+
+## Auth constraint — `validateHospitalAccess()`
+
+`getStats()`, `getDailyAppointments()`, and `getWeeklyRevenue()` all call the private
+`validateHospitalAccess(hospitalId, userId)` helper, which checks:
+
+```ts
+if (hospital.userId !== userId) throw new ForbiddenException(...)
+```
+
+This means only the user whose `id` matches `hospital.userId` (i.e. the user who
+registered the hospital) can call these three endpoints. If your test admin account
+was created via a different flow than the hospital registration, you will get a `403`.
+
+> ⚠️ **Gap E:** `GET /hospitals/:id/departments`, `GET /hospitals/:id/drug-stock`,
+> and `GET /hospitals/:id/invoices` do NOT use this helper — they use a simpler
+> hospital-existence check. So department/drug-stock/invoice calls will succeed for
+> any authenticated `HOSPITAL_ADMIN`, but dashboard stats will only succeed for the
+> admin who originally registered that hospital. This inconsistency may cause
+> confusion if you log in with a seeded admin whose `userId` does not match
+> `hospital.userId` in the database.
+
+---
+
+## Gaps summary
+
+| ID | Page | Endpoint | Issue | Blocking? |
+|----|------|----------|-------|-----------|
+| A | dashboard | `GET /hospitals/:id/dashboard/stats` | 7 backend appointment statuses bucketed into 4 frontend groups — product may want individual counts later | No |
+| B | departments | `GET /hospitals/:id/departments` | Endpoint implemented; Postgres columns `isDepartmentHead` and `HospitalStaff.department` not yet migrated to DB — will throw 500 until migration runs | **Yes** |
+| C | finance | `GET /hospitals/:id/invoices` | Invoice status field on response is `paymentStatus`, not `status` — frontend must read `invoice.paymentStatus` | Yes |
+| D | inventory | `PATCH /hospitals/:id/drug-stock/:drugId` | Request body field is `qtyOnHand`, not `quantity` — sending `quantity` is silently ignored | **Yes** |
+| E | dashboard | `GET /hospitals/:id/dashboard/stats` | `validateHospitalAccess()` uses `hospital.userId` — only the hospital's registering user can call stats; other HOSPITAL_ADMIN accounts get 403 | Yes (if multiple admins) |
+| F | dashboard | — | No procurement/spend endpoint — "Procured Value" card has no data source | No (deferred feature) |


### PR DESCRIPTION
## Summary

Integrates the four Hospital Admin portal pages  Dashboard, Departments, Finance, and Inventory  with real backend API data. All hardcoded mock values, fallback arrays, and fake constants have been removed; each page now fetches live data on mount and renders empty/loading states when the API is unavailable or returns nothing.

## Changes

**Hospital Admin Dashboard (`/hospital/admin/dashboard`)**
- Fetches `GET /hospitals/:id/dashboard/stats`, `GET /hospitals/:id/dashboard/weekly-revenue`, and `GET /hospitals/:id/drug-stock` in parallel via `Promise.allSettled`
- Stat cards (Appointments, Active Doctors, Monthly Revenue, Low Stock) now show real values; display `` while loading
- Line chart now uses real weekly revenue data (`{ label, revenue }` → `{ label, value }`)
- Removed hardcoded `activityFeed` array (no backend source); replaced with "No recent activity" empty state
- Removed fake chart fallback numbers

**Hospital Admin  Departments (`/hospital/admin/departments`)**
- Removed `SERVICE_GROUPS` constant (4 fake department cards) and `FALLBACK_EMPLOYEES` constant
- Fetches `GET /hospitals/:id/doctors`; groups doctors by specialization to generate department cards dynamically
- Employee directory maps `hospitalStaff.firstName + lastName` → name, `specialization` → department, `isAvailable` → availability badge
- Shows "Loading departments…" while fetching, "No departments found." if the API returns empty

**Hospital Admin  Finance (`/hospital/admin/finance`)**
- Removed `REVENUE_CHART_DATA`, `PAYMENT_BREAKDOWN`, and `REFUNDS` hardcoded arrays
- Fetches `GET /hospitals/:id/invoices?limit=100`; maps `paymentStatus → status`, `patient.firstName + lastName → patientName`, `issuedAt → dueDate` before passing to `<InvoiceTable>`
- KPI cards (Total Revenues, Pending Payments, Overdue Payments) compute values from the fetched invoice list; show `` while loading
- Revenue chart, payment breakdown chart, and refund table now receive empty arrays (no backend endpoint for these yet)

**Hospital Admin  Inventory (`/hospital/admin/inventory`)**
- Removed 7-item `FALLBACK_ITEMS` array; state initializes to `[]`
- Fetches `GET /hospitals/:id/drug-stock`; maps `drug.brandName` → name, `lowStockAlert` → stock badge, expiry date → alert badge (computed client-side: EXPIRED / EXPIRING ≤60d / SAFE)
- "Request Stock" button now opens an inline quantity input; Save calls `PATCH /hospitals/:id/drug-stock/:drugId` with `{ qtyOnHand }` (correct DTO field  not `quantity`)
- Table shows "Loading inventory…" while fetching

## Affected portals / areas

- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting
- [x] **Hospital Admin** (`/hospital/admin/*`)

## How to test

1. Log in as a `HOSPITAL_ADMIN` whose user ID matches `hospital.userId` in the database (the account that originally registered the hospital  required for stats/revenue endpoints due to `validateHospitalAccess()`)
2. Navigate to `/hospital/admin/dashboard`  stat cards should show real appointment count, active doctor count, monthly revenue, and low-stock item count; the line chart should show weekly revenue data
3. Navigate to `/hospital/admin/departments`  department cards should reflect actual doctor specializations seeded in the DB; employee directory should list real doctors with their names and availability
4. Navigate to `/hospital/admin/finance`  invoice table should display real patient invoices with correct names and payment statuses; KPI cards should reflect computed totals from those invoices
5. Navigate to `/hospital/admin/inventory`  drug table should list real stock items from the hospital; click "Request Stock" on any row, change the quantity, click Save, and confirm the row updates without a page reload
6. For each page: verify that no hardcoded names (Kevine Mugisha, Ella Mutesi, RF-008, Amoxicillin 500mg, etc.) appear anywhere on screen

## Checklist

- [x] `npm run build` passes clean (type-check included)
- [ ] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [x] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [ ] Manually verified the affected screens in the browser
- [x] No secrets, `.env.local`, or local-only notes committed

## Notes for reviewers

- `GET /hospitals/:id/departments` does **not** exist in the backend controller  departments are derived client-side from doctor specializations grouped from the `/doctors` response. If a `/departments` endpoint is added later, the page can be updated to call it directly.
- Revenue chart, Payment Breakdown chart, and Refund Table intentionally render empty  there are no backend endpoints for historical expense breakdown or refund records. Tracked as Gap F in `src/docs/HOSPITAL_ADMIN_BACKEND_CONTRACT.md`.
- The stats endpoints (`/dashboard/stats`, `/dashboard/weekly-revenue`) use `validateHospitalAccess()` and will return `403` for any admin whose `userId` ≠ `hospital.userId`. Documented as Gap E.
- PATCH drug stock body must be `{ qtyOnHand }` not `{ quantity }`  the task card had the wrong field name; this PR uses the correct DTO field.