### PR TITLE
feat: wire nurse portal pages to real APIs

### DIFF
--- a/src/app/hospital/nurse/dashboard/page.tsx
+++ b/src/app/hospital/nurse/dashboard/page.tsx
@@ -28,7 +28,7 @@ export default function NurseDashboardPage() {
   const { t } = useTranslation();
   const hospitalId = useHospitalId();
   const nurseUser = useHospitalNurseUser();
-  const { patients, loading: patientsLoading } = useHospitalAdmissions(hospitalId);
+  const { patients, loading: patientsLoading, error: patientsError } = useHospitalAdmissions(hospitalId);
 
   // GET /hospitals/:hospitalId/drug-stock — the ticket states this is "NURSE
   // role allowed", but src/docs/HOSPITAL_ADMIN_BACKEND_CONTRACT.md only
@@ -238,6 +238,8 @@ export default function NurseDashboardPage() {
         <div className="rounded-xl border border-gray-200 bg-white p-2 sm:p-4 divide-y divide-gray-100">
           {patientsLoading ? (
             <div className="py-8 text-center text-sm text-gray-400">{t('common.loading', 'Loading...')}</div>
+          ) : patientsError ? (
+            <div className="py-8 text-center text-sm text-red-500">{patientsError}</div>
           ) : overviewPatients.length === 0 ? (
             <div className="py-8 text-center text-sm text-gray-400">{t('hospital.noPatientsFound')}</div>
           ) : overviewPatients.map((patient) => (

--- a/src/app/hospital/nurse/dashboard/page.tsx
+++ b/src/app/hospital/nurse/dashboard/page.tsx
@@ -2,64 +2,184 @@
 
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
-import { CalendarIcon, UserGroupIcon, ChatBubbleLeftRightIcon, ClipboardDocumentListIcon, CalendarDaysIcon, ArrowRightIcon, CheckIcon } from '@heroicons/react/24/outline';
-import { nurseDashboardStats, nurseDashboardCardsData, nursePatients, nurseSchedule } from '@/mock/hospital/nurse';
-import { MOCK_NURSE } from '@/mock/hospital/user';
+import { CalendarIcon, UserGroupIcon, ChatBubbleLeftRightIcon, ClipboardDocumentListIcon, CalendarDaysIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import api, { unwrapData } from '@/lib/api';
+import { useHospitalId, useHospitalNurseUser, useHospitalAdmissions } from '@/lib/hospital';
+import type { PatientStatus } from '@/types/hospital';
+
+const OVERVIEW_LIMIT = 4;
+
+const STATUS_LABEL: Record<PatientStatus, string> = {
+  ACTIVE: 'active',
+  CRITICAL: 'critical',
+  INACTIVE: 'inactive',
+};
+
+const STATUS_COLOR: Record<PatientStatus, string> = {
+  ACTIVE: 'text-green-600',
+  CRITICAL: 'text-red-600',
+  INACTIVE: 'text-gray-500',
+};
 
 export default function NurseDashboardPage() {
   const { t } = useTranslation();
+  const hospitalId = useHospitalId();
+  const nurseUser = useHospitalNurseUser();
+  const { patients, loading: patientsLoading } = useHospitalAdmissions(hospitalId);
+
+  // GET /hospitals/:hospitalId/drug-stock — the ticket states this is "NURSE
+  // role allowed", but src/docs/HOSPITAL_ADMIN_BACKEND_CONTRACT.md only
+  // confirms it for HOSPITAL_ADMIN and hedges on other roles (a documented
+  // gap for DOCTOR already exists). Treat NURSE access as unverified and
+  // fail gracefully rather than trusting the ticket's claim.
+  const [medicationCount, setMedicationCount] = useState<number | null>(null);
+  const [medicationLoading, setMedicationLoading] = useState(true);
+  const [medicationGap, setMedicationGap] = useState(false);
+
+  useEffect(() => {
+    if (!hospitalId) {
+      setMedicationLoading(false);
+      setMedicationGap(true);
+      return;
+    }
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await api.get(`/hospitals/${hospitalId}/drug-stock`);
+        const items = unwrapData<unknown>(res.data);
+        if (!cancelled) {
+          setMedicationCount(items.length);
+          setMedicationGap(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          // TODO: backend gap — confirm GET /hospitals/:hospitalId/drug-stock
+          // actually allows Role.NURSE; falling back to an empty state on any
+          // failure (403 included) instead of crashing the dashboard.
+          console.warn('GET /hospitals/:id/drug-stock failed for NURSE role — treating as a backend gap.', err);
+          setMedicationGap(true);
+        }
+      } finally {
+        if (!cancelled) setMedicationLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [hospitalId]);
+
+  // Appointments: per the ticket, this endpoint currently only allows
+  // PATIENT, DOCTOR, HOSPITAL_ADMIN, SUPER_ADMIN — NURSE is expected to 403.
+  // Same defensive treatment as drug-stock above.
+  const [appointmentCount, setAppointmentCount] = useState<number | null>(null);
+  const [appointmentLoading, setAppointmentLoading] = useState(true);
+  const [appointmentGap, setAppointmentGap] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await api.get('/appointments');
+        const items = unwrapData<unknown>(res.data);
+        if (!cancelled) {
+          setAppointmentCount(items.length);
+          setAppointmentGap(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          // TODO: coordinate with backend team — GET /appointments does not
+          // yet list Role.NURSE among its allowed roles. Flagging as a gap
+          // instead of working around auth.
+          console.warn('GET /appointments failed for NURSE role — backend gap, coordinate with backend team.', err);
+          setAppointmentGap(true);
+        }
+      } finally {
+        if (!cancelled) setAppointmentLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
 
   const getGreeting = () => {
-  const h = new Date().getHours();
-  if (h < 12) return t('hospital.goodMorning');
-  if (h < 17) return t('hospital.goodAfternoon');
-  return t('hospital.goodEvening');
+    const h = new Date().getHours();
+    if (h < 12) return t('hospital.goodMorning');
+    if (h < 17) return t('hospital.goodAfternoon');
+    return t('hospital.goodEvening');
   };
 
-// Stats Card Styling
-  const cardStylesConfig: Record<string, { icon: any; color: string; value: number }> = {
-    patients: {
+  const statCards = [
+    {
+      key: 'patients',
       icon: UserGroupIcon,
       color: '#2563EB',
-      value: nurseDashboardStats.totalPatients,
+      title: t('hospital.myPatients'),
+      subtitle: t('hospital.totalPatients'),
+      action: t('hospital.viewPatients'),
+      href: '/hospital/nurse/patients',
+      loading: patientsLoading,
+      gap: false,
+      value: patients.length,
     },
-    tasks: {
+    {
+      key: 'medications',
       icon: ClipboardDocumentListIcon,
       color: '#F97316',
-      value: nurseDashboardStats.pendingTasks,
+      title: t('hospital.medications', 'Medications'),
+      subtitle: medicationGap ? t('hospital.backendGapPending', 'Backend endpoint pending') : t('hospital.medicationsInStock', 'Drugs in stock'),
+      action: t('hospital.viewMedications', 'View medications'),
+      href: '/hospital/nurse/medications',
+      loading: medicationLoading,
+      gap: medicationGap,
+      value: medicationCount ?? 0,
     },
-    messages: {
-      icon: ChatBubbleLeftRightIcon,
+    {
+      key: 'appointments',
+      icon: CalendarDaysIcon,
       color: '#C026D3',
-      value: nurseDashboardStats.unreadMessages,
+      title: t('hospital.appointments', 'Appointments'),
+      subtitle: appointmentGap ? t('hospital.backendGapPending', 'Backend endpoint pending') : t('hospital.appointmentsToday', "Today's appointments"),
+      action: t('hospital.viewSchedule'),
+      href: '/hospital/nurse/schedule',
+      loading: appointmentLoading,
+      gap: appointmentGap,
+      value: appointmentCount ?? 0,
     },
-  };
+    {
+      key: 'messages',
+      icon: ChatBubbleLeftRightIcon,
+      color: '#0EA5E9',
+      title: t('hospital.messages'),
+      subtitle: t('hospital.backendGapPending', 'Backend endpoint pending'),
+      action: t('hospital.viewMessages'),
+      href: '/hospital/nurse/messages',
+      loading: false,
+      // No messages API exists at all yet (see nurse/messages/page.tsx) — always a gap, not a transient failure.
+      gap: true,
+      value: 0,
+    },
+  ];
 
-  // Merge the text with style config for easier rendering
-  const statCards = nurseDashboardCardsData.map((card) => ({
-    ...card,
-    ...cardStylesConfig[card.key],
-    title: t(card.titleKey),
-    subtitle: t(card.subtitleKey),
-    action: t(card.actionKey),
-  }));
+  const overviewPatients = patients.slice(0, OVERVIEW_LIMIT);
 
   return (
     <div className="space-y-6">
       {/* Hero*/}
       <div className="rounded-2xl relative overflow-hidden w-full" style={{ background: '#EBF5FF', padding: '28px 48px' }}>
         {/*Heartbeat SVG*/}
-        <svg 
-          className="absolute right-0 top-1/2 -translate-y-1/2 opacity-10 pointer-events-none hidden sm:block sm:w-48 md:w-64 lg:w-96 xl:w-[500px]" 
+        <svg
+          className="absolute right-0 top-1/2 -translate-y-1/2 opacity-10 pointer-events-none hidden sm:block sm:w-48 md:w-64 lg:w-96 xl:w-[500px]"
           viewBox="0 0 320 140"  fill="none" preserveAspectRatio="xMidYMid meet" >
           <polyline points="0,70 55,70 80,15 108,125 135,30 162,105 188,70 320,70" stroke="#1E4D8C" strokeWidth="7" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
 
         <div className="relative z-10">
           <h1 className="text-4xl sm:text-5xl font-black mb-3" style={{ color: '#1a3470' }}>
-            {getGreeting()}, {MOCK_NURSE.firstName}.
+            {getGreeting()}, {nurseUser.userName}.
           </h1>
           <p className="text-lg" style={{ color: '#0284C7' }}>{t('hospital.welcomeNurse')}</p>
           <Link
@@ -75,13 +195,13 @@ export default function NurseDashboardPage() {
           </Link>
         </div>
       </div>
-    
+
      {/* Stat Cards */}
-    <div className="grid gap-5 md:grid-cols-3">
+    <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
       {statCards.map((card) => {const Icon = card.icon;
 
         return (
-          <div key={card.title} className="rounded-2xl bg-white px-6 py-5 min-h-[180px] flex flex-col"
+          <div key={card.key} className="rounded-2xl bg-white px-6 py-5 min-h-[180px] flex flex-col"
             style={{ border: `1px solid ${card.color}40`, }} >
 
             <div className="flex items-center gap-3 mb-8">
@@ -89,7 +209,7 @@ export default function NurseDashboardPage() {
               <h3 className="text-sm font-semibold text-gray-800"> {card.title}</h3>
             </div>
 
-            <h2 className="text-5xl font-light" style={{ color: card.color }} > {card.value} </h2>
+            <h2 className="text-5xl font-light" style={{ color: card.color }} > {card.loading ? '—' : card.gap ? '—' : card.value} </h2>
             <p className="mt-3 text-xs text-gray-500"> {card.subtitle} </p>
 
             <div className="flex-1" />
@@ -106,22 +226,26 @@ export default function NurseDashboardPage() {
     </div>
       {/* Patient Overview*/}
       <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm p-5 sm:p-6">
-       
+
         <div className="flex items-center justify-between mb-5">
           <div className="flex items-center gap-3">
             <UserGroupIcon className="h-6 w-6 text-[#2563EB]" />
             <h2 className="text-lg font-bold text-gray-800">{t('hospital.patientOverview')}</h2>
           </div>
-          <button className="text-sm font-bold text-[#2563EB] hover:underline">{t('common.viewAll')}</button>
+          <Link href="/hospital/nurse/patients" className="text-sm font-bold text-[#2563EB] hover:underline">{t('common.viewAll')}</Link>
         </div>
 
         <div className="rounded-xl border border-gray-200 bg-white p-2 sm:p-4 divide-y divide-gray-100">
-          {nursePatients.map((patient) => (
-            <div 
-              key={patient.id} 
+          {patientsLoading ? (
+            <div className="py-8 text-center text-sm text-gray-400">{t('common.loading', 'Loading...')}</div>
+          ) : overviewPatients.length === 0 ? (
+            <div className="py-8 text-center text-sm text-gray-400">{t('hospital.noPatientsFound')}</div>
+          ) : overviewPatients.map((patient) => (
+            <div
+              key={patient.id}
               className="grid grid-cols-12 gap-4 py-4 items-center px-2 hover:bg-slate-50 rounded-lg transition-colors group cursor-pointer" >
               <div className="col-span-2 sm:col-span-1 flex items-center gap-2 border-r border-gray-200 pr-2">
-                <span className="text-sm font-bold text-gray-400">{patient.id}</span>
+                <span className="text-sm font-bold text-gray-400">{patient.patientId}</span>
               </div>
 
               <div className="col-span-5 sm:col-span-3 pl-1">
@@ -132,26 +256,19 @@ export default function NurseDashboardPage() {
               </div>
 
               <div className="col-span-5 sm:col-span-2 text-center sm:text-left">
-                <span className={`text-sm font-bold ${ patient.status === 'Stable' ? 'text-green-600' : 'text-red-600' }`}>
-                  {patient.status === 'Stable' ? t('hospital.stable') : patient.status === 'High Risk' ? t('hospital.highRisk') : patient.status === 'Improving' ? t('hospital.improving') : patient.status}
+                <span className={`text-sm font-bold ${STATUS_COLOR[patient.status]}`}>
+                  {t(`hospital.${STATUS_LABEL[patient.status]}`, STATUS_LABEL[patient.status])}
                 </span>
               </div>
 
-              <div className="col-span-12 sm:col-span-5 grid grid-cols-3 gap-2 text-center sm:text-left pt-2 sm:pt-0 border-t sm:border-t-0 border-gray-100">
-                {/* BP */}
+              <div className="col-span-12 sm:col-span-5 grid grid-cols-2 gap-2 text-center sm:text-left pt-2 sm:pt-0 border-t sm:border-t-0 border-gray-100">
                 <div>
-                  <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wide">{t('hospital.bloodPressure')}</div>
-                  <div className="text-xs sm:text-sm font-bold text-gray-800 mt-0.5">{patient.bp}</div>
+                  <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wide">{t('hospital.condition')}</div>
+                  <div className="text-xs sm:text-sm font-bold text-gray-800 mt-0.5 uppercase">{patient.condition}</div>
                 </div>
-                {/* HR */}
                 <div>
-                  <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wide">{t('hospital.heartRate')}</div>
-                  <div className="text-xs sm:text-sm font-bold text-gray-800 mt-0.5">{patient.hr}</div>
-                </div>
-                {/* Temp */}
-                <div>
-                  <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wide">{t('hospital.temperature')}</div>
-                  <div className="text-xs sm:text-sm font-bold text-gray-800 mt-0.5">{patient.temperature}</div>
+                  <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wide">{t('hospital.lastVisit')}</div>
+                  <div className="text-xs sm:text-sm font-bold text-gray-800 mt-0.5">{patient.lastVisit}</div>
                 </div>
               </div>
 
@@ -163,9 +280,9 @@ export default function NurseDashboardPage() {
         </div>
 
         <div className="text-center mt-6">
-          <button className="text-sm font-bold text-[#2563EB] hover:underline">
+          <Link href="/hospital/nurse/patients" className="text-sm font-bold text-[#2563EB] hover:underline">
             {t('hospital.viewAllPatients')}
-          </button>
+          </Link>
         </div>
 
       </div>
@@ -178,31 +295,12 @@ export default function NurseDashboardPage() {
             <h2 className="font-semibold text-gray-800"> {t('hospital.todaySchedule')} </h2>
           </div>
 
-          <button className="text-sm text-[#2563EB]">{t('hospital.viewFullSchedule')}</button>
+          <Link href="/hospital/nurse/schedule" className="text-sm text-[#2563EB]">{t('hospital.viewFullSchedule')}</Link>
         </div>
 
-        <div>
-          {nurseSchedule.map((item) => (
-            <div key={item.id}
-              className="flex items-center justify-between border-b border-gray-100 px-5 py-4 last:border-b-0">
-
-              <div className="flex items-center gap-4">
-                <span className="text-sm text-gray-500 w-16 shrink-0">{item.time}</span>
-                <span className="w-2.5 h-2.5 rounded-full bg-blue-500 shrink-0" />
-                <div>
-                  <p className="text-sm font-semibold text-gray-800">{item.title}</p>
-                  <p className="text-xs text-gray-400 mt-0.5">{item.location}</p>
-                </div>
-              </div>
-
-              <span
-                className={`inline-flex items-center gap-1 rounded-lg px-3 py-1 text-xs font-semibold ${
-                item.status === 'Completed' ? 'bg-green-100 text-green-700' : 'bg-blue-50 text-blue-600' }`}>
-                {item.status === 'Completed' ? t('hospital.completed') : item.status}
-                {item.status === 'Completed' && <CheckIcon className="w-3.5 h-3.5" strokeWidth={2.5} />}
-              </span>
-            </div>
-          ))}
+        {/* TODO: no dashboard-scoped schedule endpoint exists yet (see src/docs/HOSPITAL_FRONTEND_BACKEND_GAPS.md, Gap N-3) */}
+        <div className="px-5 py-8 text-center text-sm text-gray-400">
+          {t('hospital.scheduleNotAvailable', "Today's schedule isn't available yet.")}
         </div>
       </div>
     </div>

--- a/src/app/hospital/nurse/medications/page.tsx
+++ b/src/app/hospital/nurse/medications/page.tsx
@@ -13,6 +13,14 @@ import {
     RotateCcw,
     Pill,
 } from 'lucide-react';
+// NOTE: the nurse-portal integration ticket originally asked to wire this page
+// to GET /hospitals/:hospitalId/drug-stock (inventory: brandName/quantity/
+// reorderLevel/expiryDate/lowStockAlert). That's a different concept from the
+// MAR (Medication Administration Record) shown here — which patient needs
+// which dose administered when — and this page was already live via
+// /inpatient/admissions + /mar before that ticket was written. Kept as-is;
+// drug-stock instead feeds the dashboard's medication-count stat card
+// (see src/app/hospital/nurse/dashboard/page.tsx).
 import { MOCK_MEDICATIONS, MOCK_MEDICATION_STATS } from '@/mock/hospital/medications';
 import { MedicationAdministration, MedicationStatus } from '@/types/hospital';
 import api from '@/lib/api';

--- a/src/app/hospital/nurse/messages/page.tsx
+++ b/src/app/hospital/nurse/messages/page.tsx
@@ -9,7 +9,6 @@ import {
     ChatBubbleOvalLeftEllipsisIcon,
     ClockIcon
 } from '@heroicons/react/24/outline';
-import { MOCK_CONVERSATIONS } from '@/mock/hospital/messages';
 import { Conversation, Message } from '@/types/hospital';
 
 const NAVY = '#1E3A5F';
@@ -24,7 +23,8 @@ const formatTime = (ts: string) => {
 
 export default function NurseMessagesPage() {
     const { t } = useTranslation();
-    const [conversations, setConversations] = useState<Conversation[]>(MOCK_CONVERSATIONS);
+    // No messages API exists yet — starts empty. See src/docs/HOSPITAL_FRONTEND_BACKEND_GAPS.md
+    const [conversations, setConversations] = useState<Conversation[]>([]);
     const [activeId, setActiveId] = useState<string | null>(null);
     const [inputText, setInputText] = useState('');
     const [search, setSearch] = useState('');

--- a/src/app/hospital/nurse/notes/page.tsx
+++ b/src/app/hospital/nurse/notes/page.tsx
@@ -12,57 +12,33 @@ import {
     RotateCcw,
     ChevronDown,
 } from 'lucide-react';
-import { MOCK_PATIENTS } from '@/mock/hospital/consultations';
-import { MOCK_NURSE } from '@/mock/hospital/user';
 import type { NursingNote } from '@/types/hospital';
 import { useTranslation } from 'react-i18next';
+import { useHospitalId, useHospitalNurseUser, useHospitalAdmissions } from '@/lib/hospital';
 
-const NURSE_NAME = `${MOCK_NURSE.firstName} ${MOCK_NURSE.lastName}`;
-const MOCK_TODAY = '2026-06-09';
-
-const INITIAL_NOTES: NursingNote[] = [
-    {
-        id: 'note-001',
-        patientName: MOCK_PATIENTS[3].name,
-        nurseName: NURSE_NAME,
-        date: MOCK_TODAY,
-        time: '05:15 PM',
-        observationNotes: 'Patient is alert and stable post-load, Vitals stable: BP 115/70, HR 82, Temp 36.7C.',
-        careActivities: '',
-        additionalComments: '',
-    },
-    {
-        id: 'note-002',
-        patientName: MOCK_PATIENTS[4].name,
-        nurseName: NURSE_NAME,
-        date: MOCK_TODAY,
-        time: '04:30 PM',
-        observationNotes: 'Patient complains of mild shoulder pain post-surgery but is stable. Client education reviewed for breath sounds.',
-        careActivities: '',
-        additionalComments: '',
-    },
-    {
-        id: 'note-003',
-        patientName: MOCK_PATIENTS[5].name,
-        nurseName: NURSE_NAME,
-        date: '2026-06-08',
-        time: '10:15 AM',
-        observationNotes: 'Post-operative Day 1 following laparoscopic cholecystectomy. Patient complains of pain around incision site.',
-        careActivities: '',
-        additionalComments: '',
-    },
-];
+function formatDateTimeInput(date: Date): string {
+    const datePart = date.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
+    const timePart = date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+    return `${datePart} ${timePart}`;
+}
 
 export default function NursingNotesPage() {
     const { t } = useTranslation();
+    const hospitalId = useHospitalId();
+    const nurseUser = useHospitalNurseUser();
+    const { patients } = useHospitalAdmissions(hospitalId);
 
-    const [notes, setNotes] = useState<NursingNote[]>(INITIAL_NOTES);
+    const today = useMemo(() => new Date(), []);
+    const todayIso = useMemo(() => today.toISOString().slice(0, 10), [today]);
+
+    // No backend endpoint exists for nursing notes yet — starts empty, stays local-only.
+    const [notes, setNotes] = useState<NursingNote[]>([]);
     const [search, setSearch] = useState('');
     const [patientFilter, setPatientFilter] = useState('');
-    const [dateFilter, setDateFilter] = useState(MOCK_TODAY);
+    const [dateFilter, setDateFilter] = useState(todayIso);
 
     const [selectedPatient, setSelectedPatient] = useState('');
-    const [dateTime, setDateTime] = useState('06/09/2026 05:20 PM');
+    const [dateTime, setDateTime] = useState(() => formatDateTimeInput(today));
     const [observationNotes, setObservationNotes] = useState('');
     const [careActivities, setCareActivities] = useState('');
     const [additionalComments, setAdditionalComments] = useState('');
@@ -78,15 +54,16 @@ export default function NursingNotesPage() {
     }, [notes, search, patientFilter, dateFilter]);
 
     const stats = [
-        { label: t('hospital.notesToday'), value: notes.filter((n) => n.date === MOCK_TODAY).length, icon: <FileText className="w-5 h-5 text-[#38BDF8]" />, bgColor: 'bg-[#F0F9FF]', borderColor: 'border-[#E0F2FE]' },
+        { label: t('hospital.notesToday'), value: notes.filter((n) => n.date === todayIso).length, icon: <FileText className="w-5 h-5 text-[#38BDF8]" />, bgColor: 'bg-[#F0F9FF]', borderColor: 'border-[#E0F2FE]' },
         { label: t('hospital.recentNotes'), value: notes.length, icon: <Clock className="w-5 h-5 text-purple-500" />, bgColor: 'bg-purple-50', borderColor: 'border-purple-100' },
         { label: t('hospital.patientsMonitored'), value: new Set(notes.map((n) => n.patientName)).size, icon: <Users className="w-5 h-5 text-green-500" />, bgColor: 'bg-green-50', borderColor: 'border-green-100' },
-        { label: t('hospital.pendingDocumentation'), value: 2, icon: <AlertCircle className="w-5 h-5 text-red-500" />, bgColor: 'bg-red-50', borderColor: 'border-red-100' },
+        // No backend endpoint tracks pending documentation yet — placeholder until one exists.
+        { label: t('hospital.pendingDocumentation'), value: 0, icon: <AlertCircle className="w-5 h-5 text-red-500" />, bgColor: 'bg-red-50', borderColor: 'border-red-100' },
     ];
 
     const resetForm = () => {
         setSelectedPatient('');
-        setDateTime('06/09/2026 05:20 PM');
+        setDateTime(formatDateTimeInput(new Date()));
         setObservationNotes('');
         setCareActivities('');
         setAdditionalComments('');
@@ -94,12 +71,14 @@ export default function NursingNotesPage() {
 
     const submitDocumentation = () => {
         if (!selectedPatient || !observationNotes) return;
+        // No backend endpoint exists for nursing notes yet — saved to local state only.
+        console.warn('Nursing note submission has no backend endpoint yet — saved to local state only.');
         const [datePart, ...timeParts] = dateTime.split(' ');
         const newNote: NursingNote = {
             id: `note-${Date.now()}`,
             patientName: selectedPatient,
-            nurseName: NURSE_NAME,
-            date: datePart === '06/09/2026' ? MOCK_TODAY : datePart,
+            nurseName: nurseUser.userName,
+            date: datePart,
             time: timeParts.join(' ') || dateTime,
             observationNotes,
             careActivities,
@@ -157,7 +136,7 @@ export default function NursingNotesPage() {
                                 className="w-full pl-4 pr-10 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-xs font-bold text-[#1E3A5F] appearance-none cursor-pointer"
                             >
                                 <option value="">{t('hospital.allPatients')}</option>
-                                {MOCK_PATIENTS.map((p) => (
+                                {patients.map((p) => (
                                     <option key={p.id} value={p.name}>{p.name}</option>
                                 ))}
                             </select>
@@ -210,7 +189,7 @@ export default function NursingNotesPage() {
                                         className="w-full pl-4 pr-10 py-3 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] appearance-none cursor-pointer"
                                     >
                                         <option value="">{t('hospital.selectPatient')}</option>
-                                        {MOCK_PATIENTS.map((p) => (
+                                        {patients.map((p) => (
                                             <option key={p.id} value={p.name}>{p.name}</option>
                                         ))}
                                     </select>

--- a/src/app/hospital/nurse/notes/page.tsx
+++ b/src/app/hospital/nurse/notes/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
     Search,
     FileText,
@@ -26,9 +26,9 @@ export default function NursingNotesPage() {
     const { t } = useTranslation();
     const hospitalId = useHospitalId();
     const nurseUser = useHospitalNurseUser();
-    const { patients } = useHospitalAdmissions(hospitalId);
+    const { patients, loading: patientsLoading } = useHospitalAdmissions(hospitalId);
 
-    const today = useMemo(() => new Date(), []);
+    const [today] = useState(() => new Date());
     const todayIso = useMemo(() => today.toISOString().slice(0, 10), [today]);
 
     // No backend endpoint exists for nursing notes yet — starts empty, stays local-only.
@@ -37,7 +37,7 @@ export default function NursingNotesPage() {
     const [patientFilter, setPatientFilter] = useState('');
     const [dateFilter, setDateFilter] = useState(todayIso);
 
-    const [selectedPatient, setSelectedPatient] = useState('');
+    const [selectedPatientId, setSelectedPatientId] = useState('');
     const [dateTime, setDateTime] = useState(() => formatDateTimeInput(today));
     const [observationNotes, setObservationNotes] = useState('');
     const [careActivities, setCareActivities] = useState('');
@@ -62,7 +62,7 @@ export default function NursingNotesPage() {
     ];
 
     const resetForm = () => {
-        setSelectedPatient('');
+        setSelectedPatientId('');
         setDateTime(formatDateTimeInput(new Date()));
         setObservationNotes('');
         setCareActivities('');
@@ -70,15 +70,18 @@ export default function NursingNotesPage() {
     };
 
     const submitDocumentation = () => {
-        if (!selectedPatient || !observationNotes) return;
+        const patient = patients.find((p) => p.patientId === selectedPatientId);
+        if (!patient || !observationNotes) return;
         // No backend endpoint exists for nursing notes yet — saved to local state only.
         console.warn('Nursing note submission has no backend endpoint yet — saved to local state only.');
         const [datePart, ...timeParts] = dateTime.split(' ');
+        const [mm, dd, yyyy] = datePart.split('/');
+        const isoDate = yyyy && mm && dd ? `${yyyy}-${mm}-${dd}` : todayIso;
         const newNote: NursingNote = {
             id: `note-${Date.now()}`,
-            patientName: selectedPatient,
+            patientName: patient.name,
             nurseName: nurseUser.userName,
-            date: datePart,
+            date: isoDate,
             time: timeParts.join(' ') || dateTime,
             observationNotes,
             careActivities,
@@ -133,7 +136,8 @@ export default function NursingNotesPage() {
                             <select
                                 value={patientFilter}
                                 onChange={(e) => setPatientFilter(e.target.value)}
-                                className="w-full pl-4 pr-10 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-xs font-bold text-[#1E3A5F] appearance-none cursor-pointer"
+                                disabled={patientsLoading}
+                                className="w-full pl-4 pr-10 py-2.5 bg-white border border-[#E2E8F0] rounded-xl text-xs font-bold text-[#1E3A5F] appearance-none cursor-pointer disabled:opacity-60"
                             >
                                 <option value="">{t('hospital.allPatients')}</option>
                                 {patients.map((p) => (
@@ -184,13 +188,14 @@ export default function NursingNotesPage() {
                                 <label className="text-xs font-bold text-[#1E3A5F] uppercase tracking-wide ml-1">{t('hospital.patientName')}</label>
                                 <div className="relative">
                                     <select
-                                        value={selectedPatient}
-                                        onChange={(e) => setSelectedPatient(e.target.value)}
-                                        className="w-full pl-4 pr-10 py-3 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] appearance-none cursor-pointer"
+                                        value={selectedPatientId}
+                                        onChange={(e) => setSelectedPatientId(e.target.value)}
+                                        disabled={patientsLoading}
+                                        className="w-full pl-4 pr-10 py-3 bg-[#F8FAFC] border border-[#E2E8F0] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#38BDF8] appearance-none cursor-pointer disabled:opacity-60"
                                     >
-                                        <option value="">{t('hospital.selectPatient')}</option>
+                                        <option value="">{patientsLoading ? t('common.loading', 'Loading...') : t('hospital.selectPatient')}</option>
                                         {patients.map((p) => (
-                                            <option key={p.id} value={p.name}>{p.name}</option>
+                                            <option key={p.id} value={p.patientId}>{p.name}</option>
                                         ))}
                                     </select>
                                     <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 text-[#94A3B8] w-5 h-5 pointer-events-none" />
@@ -253,7 +258,7 @@ export default function NursingNotesPage() {
                             </button>
                             <button
                                 onClick={submitDocumentation}
-                                disabled={!selectedPatient || !observationNotes}
+                                disabled={!selectedPatientId || !observationNotes || patientsLoading}
                                 className="px-8 py-3 bg-[#38BDF8] text-white text-sm font-bold rounded-xl hover:bg-[#0EA5E9] transition-all shadow-md flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <Save className="w-4 h-4" />

--- a/src/app/hospital/nurse/patients/page.tsx
+++ b/src/app/hospital/nurse/patients/page.tsx
@@ -1,16 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Search, Filter, MoreVertical, ChevronLeft, ChevronRight,
   Users, BedDouble, Activity, UserCheck,
 } from 'lucide-react';
-import { MOCK_PATIENTS } from '@/mock/hospital/consultations';
 import type { PatientStatus } from '@/types/hospital';
 import { useTranslation } from 'react-i18next';
-import api from '@/lib/api';
-import { useHospitalId } from '@/lib/hospital';
-import axios from 'axios';
+import { useHospitalId, useHospitalAdmissions } from '@/lib/hospital';
 
 const PAGE_SIZE = 3;
 
@@ -20,121 +17,17 @@ const STATUS_BADGE: Record<PatientStatus, string> = {
   INACTIVE: 'bg-gray-100 text-gray-600',
 };
 
-interface PatientRow {
-  id: string;
-  patientId: string;
-  name: string;
-  age: string;
-  gender: string;
-  lastVisit: string;
-  condition: string;
-  status: PatientStatus;
-}
-
-function formatLastVisit(value?: string) {
-  if (!value) return '—';
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return '—';
-  return parsed.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
-}
-
-function deriveStatus(status?: string): PatientStatus {
-  const normalized = (status ?? '').toUpperCase();
-  if (normalized === 'CRITICAL') return 'CRITICAL';
-  if (normalized === 'ACTIVE') return 'ACTIVE';
-  return 'INACTIVE';
-}
-
 export default function NursePatientsPage() {
   const { t } = useTranslation();
   const hospitalId = useHospitalId();
+  const { patients, loading, error, useMockFallback } = useHospitalAdmissions(hospitalId);
 
-  const [patients, setPatients] = useState<PatientRow[]>([]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatus] = useState<PatientStatus | 'ALL'>('ALL');
   const [conditionFilter, setCondition] = useState('ALL');
   const [lastVisitFilter, setLastVisit] = useState('ALL');
   const [page, setPage] = useState(1);
   const [now] = useState(() => Date.now());
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [useMockFallback, setUseMockFallback] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!hospitalId) {
-      setUseMockFallback(true);
-      setPatients(MOCK_PATIENTS as unknown as PatientRow[]);
-      setLoading(false);
-      setError(null);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const loadPatients = async () => {
-      setLoading(true);
-      setError(null);
-      setUseMockFallback(false);
-
-      try {
-        const response = await api.get(`/inpatient/admissions?hospitalId=${hospitalId}`);
-        const payload = response.data;
-        const admissions = Array.isArray(payload)
-          ? payload
-          : Array.isArray(payload?.data)
-            ? payload.data
-            : [];
-
-        const mappedPatients = admissions.map((item: any) => {
-          const patient = item.patient ?? {};
-          const patientName = [patient.firstName, patient.lastName].filter(Boolean).join(' ').trim() || 'Unknown patient';
-          const patientId = patient.mrn || patient.id || item.id || '—';
-          const condition = String(item.reason || 'Stable').trim() || 'Stable';
-
-          return {
-            id: item.id,
-            patientId,
-            name: patientName,
-            age: patient.age ? String(patient.age) : '—',
-            gender: patient.gender || '—',
-            lastVisit: formatLastVisit(item.updatedAt || item.createdAt),
-            condition,
-            status: deriveStatus(item.status),
-          } as PatientRow;
-        });
-
-        if (!cancelled) {
-          setPatients(mappedPatients);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          if (process.env.NODE_ENV !== 'production') {
-            setUseMockFallback(true);
-            setPatients(MOCK_PATIENTS as unknown as PatientRow[]);
-            setError(null);
-          } else {
-            const message = axios.isAxiosError(err)
-              ? err.response?.data?.message || 'Unable to load patient data right now.'
-              : 'Unable to load patient data right now.';
-            setError(message);
-            setPatients([]);
-          }
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    loadPatients();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [hospitalId]);
 
   const conditions = useMemo(() => ['ALL', ...Array.from(new Set(patients.map((p) => p.condition)))], [patients]);
 

--- a/src/app/hospital/nurse/settings/page.tsx
+++ b/src/app/hospital/nurse/settings/page.tsx
@@ -2,25 +2,19 @@
 
 import { useState, useRef } from 'react';
 import { Settings, CheckCircle, Pencil, Camera } from 'lucide-react';
-import { MOCK_HOSPITAL_SETTINGS } from '@/mock/hospital/settings';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/context/AuthContext';
+import { useHospitalNurseUser } from '@/lib/hospital';
 
 const NAVY     = '#1E3A5F';
 const TEAL     = '#38BDF8';
 const GRADIENT = 'linear-gradient(90deg, #0284C7 0%, #38BDF8 100%)';
 
-const mockNurse = {
-  name:          'Claudine Umutoni',
-  initials:      'CU',
-  role:          'Registered Nurse',
-  email:         'claudine.umutoni@evuze.rw',
-  phone:         '+250789384713',
-  hospital:      MOCK_HOSPITAL_SETTINGS.hospitalName,
-  specialization:'Medical Surgery',
-  licenseNumber: 'xxxx-xxxx-xxxx',
-  workingHours:  '10 AM - 5PM',
-  status:        'APPROVED' as const,
-};
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '';
+  return (parts[0][0] + (parts[1]?.[0] ?? '')).toUpperCase();
+}
 
 type Tab = 'profile' | 'department' | 'changePassword';
 
@@ -33,14 +27,31 @@ const labelCls = 'block text-xs font-bold text-gray-600 uppercase tracking-wides
 
 export default function NurseSettingsPage() {
   const { t } = useTranslation();
+  const { user } = useAuth();
+  const nurseUser = useHospitalNurseUser();
+
+  // No hospital-nurse profile endpoint exists yet (GET /staff/profile/me is
+  // pharmacy-nurse only) — specialization/phone/licenseNumber/workingHours
+  // have no backend source and start empty until one exists.
+  const nurse = {
+    name: nurseUser.userName,
+    initials: getInitials(nurseUser.userName),
+    role: nurseUser.roleLabel,
+    email: user?.email ?? '',
+    phone: '',
+    hospital: nurseUser.hospitalName,
+    specialization: '',
+    licenseNumber: '',
+    workingHours: '',
+  };
 
   const [activeTab,      setActiveTab]      = useState<Tab>('profile');
   const [editingProfile, setEditingProfile] = useState(false);
   const [profileForm,    setProfileForm]    = useState({
-    fullName:       mockNurse.name,
-    email:          mockNurse.email,
-    phone:          mockNurse.phone,
-    specialization: mockNurse.specialization,
+    fullName:       nurse.name,
+    email:          nurse.email,
+    phone:          nurse.phone,
+    specialization: nurse.specialization,
   });
   const [passwordForm, setPasswordForm] = useState({
     current: '',
@@ -113,9 +124,9 @@ export default function NurseSettingsPage() {
             >
               {avatarUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img src={avatarUrl} alt={mockNurse.name} className="w-full h-full object-cover" />
+                <img src={avatarUrl} alt={nurse.name} className="w-full h-full object-cover" />
               ) : (
-                mockNurse.initials
+                nurse.initials
               )}
             </div>
             <button
@@ -134,16 +145,16 @@ export default function NurseSettingsPage() {
               className="hidden"
             />
           </div>
-          <p className="font-bold text-base sm:text-lg" style={{ color: NAVY }}>{mockNurse.name}</p>
-          <p className="text-sm text-gray-500 mt-0.5">{mockNurse.role}</p>
+          <p className="font-bold text-base sm:text-lg" style={{ color: NAVY }}>{nurse.name}</p>
+          <p className="text-sm text-gray-500 mt-0.5">{nurse.role}</p>
 
           <div className="w-full border-t border-gray-100 my-5" />
 
           <div className="w-full text-left space-y-4">
             {[
-              { label: t('common.email'),        value: mockNurse.email,    extra: 'break-all' },
-              { label: t('common.phone'), value: mockNurse.phone,    extra: '' },
-              { label: t('hospital.hospital'),     value: mockNurse.hospital, teal: true },
+              { label: t('common.email'),        value: nurse.email,    extra: 'break-all' },
+              { label: t('common.phone'), value: nurse.phone,    extra: '' },
+              { label: t('hospital.hospital'),     value: nurse.hospital, teal: true },
             ].map(({ label, value, extra, teal }) => (
               <div key={label}>
                 <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-0.5">{label}</p>
@@ -223,10 +234,10 @@ export default function NurseSettingsPage() {
               </div>
               <div className="space-y-5">
                 {[
-                  { label: t('hospital.specialization'), value: mockNurse.specialization },
-                  { label: t('hospital.licenseNumber'), value: mockNurse.licenseNumber },
-                  { label: t('hospital.hospital'),       value: mockNurse.hospital },
-                  { label: t('hospital.workingHours'),  value: mockNurse.workingHours },
+                  { label: t('hospital.specialization'), value: nurse.specialization },
+                  { label: t('hospital.licenseNumber'), value: nurse.licenseNumber },
+                  { label: t('hospital.hospital'),       value: nurse.hospital },
+                  { label: t('hospital.workingHours'),  value: nurse.workingHours },
                 ].map(({ label, value }) => (
                   <div key={label} className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-6 text-sm">
                     <span className="sm:w-40 text-gray-500 font-medium shrink-0">{label}</span>

--- a/src/app/hospital/nurse/settings/page.tsx
+++ b/src/app/hospital/nurse/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Settings, CheckCircle, Pencil, Camera } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/AuthContext';
@@ -53,6 +53,18 @@ export default function NurseSettingsPage() {
     phone:          nurse.phone,
     specialization: nurse.specialization,
   });
+
+  // Hydrate the form once auth loads — the initial useState value above is ''
+  // when user is null on first render; this effect syncs it when data arrives.
+  useEffect(() => {
+    if (!nurse.name || editingProfile) return;
+    setProfileForm({
+      fullName:       nurse.name,
+      email:          nurse.email,
+      phone:          nurse.phone,
+      specialization: nurse.specialization,
+    });
+  }, [nurse.name, nurse.email, editingProfile]);
   const [passwordForm, setPasswordForm] = useState({
     current: '',
     newPass: '',

--- a/src/lib/hospital.ts
+++ b/src/lib/hospital.ts
@@ -1,10 +1,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 import { useAuth } from '@/context/AuthContext';
 import { MOCK_DOCTOR, MOCK_ADMIN, MOCK_NURSE, MOCK_RECEPTIONIST } from '@/mock/hospital/user';
+import { MOCK_PATIENTS } from '@/mock/hospital/consultations';
 import api from '@/lib/api';
-import type { DashboardStats, WeeklyRevenue } from '@/types/hospital';
+import type { DashboardStats, WeeklyRevenue, PatientStatus } from '@/types/hospital';
 
 /**
  * Resolves the hospitalId to use for hospital admin API calls.
@@ -219,4 +221,128 @@ export function useHospitalDashboardStats(hospitalId: string | undefined): Hospi
   }, [hospitalId]);
 
   return { stats, weeklyRevenue, loading, error };
+}
+
+// ── Shared hospital admissions (patient list) ───────────────────────────────
+//
+// GET /inpatient/admissions?hospitalId= is the nurse portal's real "patient
+// list" source — GET /hospitals/:id/patients doesn't exist on the backend yet
+// (see src/docs/BACKEND_GAPS_SUMMARY.md, Gap E-6). nurse/patients, nurse/notes
+// (patient picker), and nurse/dashboard (Patient Overview) all need the same
+// hospital-scoped patient list, so it's fetched here once instead of being
+// copy-pasted per page. Falls back to MOCK_PATIENTS only when there's no
+// hospitalId, or (in non-production) when the request errors.
+export interface HospitalPatientRow {
+  id: string;
+  patientId: string;
+  name: string;
+  age: string;
+  gender: string;
+  lastVisit: string;
+  condition: string;
+  status: PatientStatus;
+}
+
+export interface HospitalAdmissionsData {
+  patients: HospitalPatientRow[];
+  loading: boolean;
+  error: string | null;
+  useMockFallback: boolean;
+}
+
+function formatAdmissionLastVisit(value?: string) {
+  if (!value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '—';
+  return parsed.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function deriveAdmissionStatus(status?: string): PatientStatus {
+  const normalized = (status ?? '').toUpperCase();
+  if (normalized === 'CRITICAL') return 'CRITICAL';
+  if (normalized === 'ACTIVE') return 'ACTIVE';
+  return 'INACTIVE';
+}
+
+export function useHospitalAdmissions(hospitalId: string | undefined): HospitalAdmissionsData {
+  const [patients, setPatients] = useState<HospitalPatientRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [useMockFallback, setUseMockFallback] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!hospitalId) {
+      setUseMockFallback(true);
+      setPatients(MOCK_PATIENTS as unknown as HospitalPatientRow[]);
+      setLoading(false);
+      setError(null);
+      return () => { cancelled = true; };
+    }
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      setUseMockFallback(false);
+
+      try {
+        const response = await api.get(`/inpatient/admissions?hospitalId=${hospitalId}`);
+        const payload = response.data;
+        const admissions = Array.isArray(payload)
+          ? payload
+          : Array.isArray(payload?.data)
+            ? payload.data
+            : [];
+
+        const mapped = admissions.map((item: any) => {
+          const patient = item.patient ?? {};
+          const patientName = [patient.firstName, patient.lastName].filter(Boolean).join(' ').trim() || 'Unknown patient';
+          const patientId = patient.mrn || patient.id || item.id || '—';
+          const condition = String(item.reason || 'Stable').trim() || 'Stable';
+
+          return {
+            id: item.id,
+            patientId,
+            name: patientName,
+            age: patient.age ? String(patient.age) : '—',
+            gender: patient.gender || '—',
+            lastVisit: formatAdmissionLastVisit(item.updatedAt || item.createdAt),
+            condition,
+            status: deriveAdmissionStatus(item.status),
+          } as HospitalPatientRow;
+        });
+
+        if (!cancelled) {
+          setPatients(mapped);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          if (process.env.NODE_ENV !== 'production') {
+            setUseMockFallback(true);
+            setPatients(MOCK_PATIENTS as unknown as HospitalPatientRow[]);
+            setError(null);
+          } else {
+            const message = axios.isAxiosError(err)
+              ? err.response?.data?.message || 'Unable to load patient data right now.'
+              : 'Unable to load patient data right now.';
+            setError(message);
+            setPatients([]);
+          }
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hospitalId]);
+
+  return { patients, loading, error, useMockFallback };
 }


### PR DESCRIPTION
## Summary

Wires the 6 nurse portal pages (dashboard, patients, notes, medications, messages, settings) to real backend data using `hospitalId` from the authenticated nurse's JWT, per the nurse portal integration ticket.

Two things surfaced during research that changed the shape of this from the ticket's original description — flagging both here rather than silently deviating:

1. **`patients` and `medications` were already wired to real endpoints** before this PR (`GET /inpatient/admissions?hospitalId=`, mock demoted to a dev-only fallback). The ticket's `GET /hospitals/:hospitalId/patients` doesn't exist on the backend (`src/docs/BACKEND_GAPS_SUMMARY.md`, Gap E-6 — only `POST :id/patients/search` exists). The real remaining work was dashboard, notes' patient picker, messages, and settings.
2. **`nurse/medications` keeps its current MAR (Medication Administration Record) integration**, not the ticket's drug-stock/inventory description — different clinical concept (dose administration vs. ward stock), already live and working. Drug-stock is used for the dashboard's medication-count stat card instead. See the `docs(nurse)` commit for the full rationale — happy to revisit if the intent really was to convert this page.

## Changes (one commit per area)
- `feat: add useHospitalAdmissions shared hook` — extracted from `patients/page.tsx` into `src/lib/hospital.ts`, reused by `notes` and `dashboard`
- `feat: wire dashboard to real APIs` — greeting, patient stat/list, medication-count (drug-stock), appointment-count (defensive), schedule/messages shown as backend-gap empty states
- `feat: wire notes patient picker to live data`
- `feat: remove mock conversations, add empty state` (messages)
- `feat: remove mock profile, seed from real session` (settings)
- `docs: note why medications kept its MAR integration`

## Verification done

**Static:**
- `npm run build` — clean, no TypeScript errors
- `npm run lint` — zero errors/warnings on all 7 changed files (the only lint failures in the repo are pre-existing, in unrelated files: scratch scripts already being removed in PR #128, and a pre-existing React Compiler warning in `admin/staff/page.tsx`)

**Against the live backend, authenticated as `nurse0_0@hospital.com`:**
- `GET /hospitals/:hospitalId/drug-stock` → **200**, empty array (not a permission gap — just no seeded stock for this hospital)
- `GET /appointments` → **403** (confirms the ticket's stated NURSE-role gap; dashboard handles this with an empty/TODO state + console warning, not a crash)
- `GET /inpatient/admissions?hospitalId=` → **404** on this backend deployment — pre-existing, not introduced by this PR (same code path existed in `patients/page.tsx` before these changes); dev-mode mock fallback covers it gracefully
- All 6 nurse routes return **200** through the auth middleware with a real hospital-NURSE JWT (role/hospitalId gating in `src/middleware.tsx` works correctly for this role)
- No stray mock imports remain except `medications.tsx`'s intentional dev-only fallback


## Test plan
- [ ] Log in as `nurse0_0@hospital.com` / `Test@1234` and click through all 6 pages
- [ ] Confirm each page's data actually renders (not just that the route loads)
- [ ] Confirm dashboard's medication/appointment cards show sensible empty states given the 403/empty-array results above
- [ ] Confirm notes patient picker and submission still work end-to-end
- [ ] Confirm messages/settings empty states look right