### PR TITLE
 Changes to be committed:

### DIFF
--- a/src/app/hospital/doctor/consultations/page.tsx
+++ b/src/app/hospital/doctor/consultations/page.tsx
@@ -17,6 +17,50 @@ const STATUS_KEY: Record<ConsultationStatus, string> = {
   PENDING: 'hospital.pending',
 };
 
+// Raw shape returned by GET /appointments (confirmed in DOCTOR_REMAINING_PAGES_API_GAPS.md).
+// `scheduledAt` is the date field — the API does NOT return a field named `date`.
+// `diagnosisSummary` is only confirmed for GET /appointments/:id (single record), not the list.
+interface AppointmentRaw {
+  id: string;
+  scheduledAt?: string;
+  status: string;
+  type?: string;
+  reason?: string;
+  diagnosisSummary?: string;
+  patient: { firstName: string; lastName: string };
+}
+
+// TODO: verify field mapping against Swagger — see DOCTOR_PORTAL_BACKEND_CONTRACT.md
+function mapToConsultation(a: AppointmentRaw): Consultation {
+  return {
+    id: a.id,
+    patientName:
+      `${a.patient?.firstName ?? ''} ${a.patient?.lastName ?? ''}`.trim() || '—',
+    // scheduledAt is the confirmed date field from GET /appointments.
+    date: a.scheduledAt
+      ? new Date(a.scheduledAt).toLocaleDateString([], {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
+      : '—',
+    type: a.type ?? '—',
+    // diagnosisSummary confirmed only for GET /appointments/:id — may be absent in the list.
+    diagnosis: a.diagnosisSummary ?? '—',
+    // TODO: duration not provided by GET /appointments — show '—' until endpoint confirmed
+    duration: '—',
+    // gender, age, bp are not included in the appointments response.
+    // TODO: populate once GET /consultations?doctorId=:id is confirmed available in Swagger
+    //       and its response shape is verified — see DOCTOR_PORTAL_BACKEND_CONTRACT.md
+    status:
+      a.status === 'COMPLETED'
+        ? 'COMPLETED'
+        : a.status === 'PENDING' || a.status === 'CONFIRMED'
+        ? 'PENDING'
+        : 'ACTIVE',
+  };
+}
+
 export default function HospitalDoctorConsultationsPage() {
   const { t } = useTranslation();
   const [search, setSearch] = useState('');
@@ -26,39 +70,26 @@ export default function HospitalDoctorConsultationsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function loadConsultations() {
-      try {
-        setLoading(true);
-        // GET /appointments is auto-scoped to the authenticated doctor via JWT.
-        // We adapt the response to the Consultation shape; gender/age/bp are
-        // not included in the appointments include — see DOCTOR_REMAINING_PAGES_API_GAPS.md.
-        const res = await api.get('/appointments');
-        const raw = unwrapData<{
-          id: string; date: string; status: string; type?: string;
-          reason?: string; diagnosisSummary?: string;
-          patient: { firstName: string; lastName: string };
-        }>(res.data);
-
-        const mapped: Consultation[] = raw.map(a => ({
-          id:        a.id,
-          patientName: `${a.patient?.firstName ?? ''} ${a.patient?.lastName ?? ''}`.trim() || '—',
-          date:      new Date(a.date).toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' }),
-          type:      a.type ?? 'CONSULTATION',
-          diagnosis: a.diagnosisSummary,
-          status:    a.status === 'COMPLETED' ? 'COMPLETED' : a.status === 'PENDING' || a.status === 'CONFIRMED' ? 'PENDING' : 'ACTIVE',
-        }));
-
-        setConsultations(mapped);
-        setError(null);
-      } catch (err) {
-        console.error('Failed to fetch consultations:', err);
-        setError(t('hospital.failedLoadConsultations'));
-      } finally {
-        setLoading(false);
-      }
+  const fetchConsultations = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // TODO: switch to GET /consultations?doctorId=:id once confirmed available in Swagger.
+      // Checked DOCTOR_REMAINING_PAGES_API_GAPS.md — endpoint not listed; falling back to
+      // GET /appointments which is doctor-scoped via JWT.
+      const res = await api.get('/appointments');
+      const raw = unwrapData<AppointmentRaw>(res.data);
+      setConsultations(raw.map(mapToConsultation));
+    } catch (err) {
+      console.error('Failed to fetch consultations:', err);
+      setError(t('hospital.failedLoadConsultations'));
+    } finally {
+      setLoading(false);
     }
-    loadConsultations();
+  };
+
+  useEffect(() => {
+    fetchConsultations();
   }, []);
 
   const filtered = consultations.filter(c =>
@@ -79,10 +110,26 @@ export default function HospitalDoctorConsultationsPage() {
         </p>
       </div>
 
+      {/* Error banner */}
+      {error && !loading && (
+        <div className="flex items-center justify-between bg-red-50 border border-red-200 rounded-2xl px-5 py-4">
+          <p className="text-sm text-red-700">{error}</p>
+          <button
+            onClick={fetchConsultations}
+            className="text-xs font-semibold text-red-600 hover:text-red-800"
+          >
+            {t('common.retry', 'Retry')}
+          </button>
+        </div>
+      )}
+
       {/* Split panel */}
       <div className="flex gap-4">
         {/* Left — queue (fixed height, scrollable list) */}
-        <div className="w-72 shrink-0 bg-white rounded-2xl border border-gray-200 shadow-sm flex flex-col overflow-hidden" style={{ height: 520 }}>
+        <div
+          className="w-72 shrink-0 bg-white rounded-2xl border border-gray-200 shadow-sm flex flex-col overflow-hidden"
+          style={{ height: 520 }}
+        >
           {/* Title row */}
           <div className="px-5 py-4 border-b border-gray-200 shrink-0">
             <h2 className="text-base font-bold text-gray-900">{t('hospital.queueForToday')}</h2>
@@ -118,17 +165,22 @@ export default function HospitalDoctorConsultationsPage() {
                 <button
                   key={c.id}
                   onClick={() => setSelected(c.id)}
-                  className={`w-full text-left px-5 py-4 transition-colors ${selectedId === c.id ? 'bg-blue-50' : 'hover:bg-gray-50'
-                    }`}
+                  className={`w-full text-left px-5 py-4 transition-colors ${
+                    selectedId === c.id ? 'bg-blue-50' : 'hover:bg-gray-50'
+                  }`}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div className="min-w-0">
                       <p className="text-sm font-bold text-gray-900 truncate">{c.patientName}</p>
+                      {/* gender/age/bp not provided by GET /appointments */}
+                      {/* TODO: populate once GET /consultations?doctorId=:id is confirmed */}
                       <p className="text-xs text-gray-500 mt-1">
-                        {c.gender}, {c.age} years · BP {c.bp}
+                        {c.gender ?? '—'} · {c.age != null ? `${c.age} yrs` : '—'} · BP {c.bp ?? '—'}
                       </p>
                     </div>
-                    <span className={`shrink-0 text-[10px] font-semibold px-2.5 py-1 rounded-full ${STATUS_BADGE[c.status]}`}>
+                    <span
+                      className={`shrink-0 text-[10px] font-semibold px-2.5 py-1 rounded-full ${STATUS_BADGE[c.status]}`}
+                    >
                       {t(STATUS_KEY[c.status] ?? c.status)}
                     </span>
                   </div>
@@ -147,8 +199,10 @@ export default function HospitalDoctorConsultationsPage() {
             <div className="w-full h-full p-8 overflow-y-auto">
               <div className="mb-6">
                 <h2 className="text-xl font-bold text-gray-900">{selected.patientName}</h2>
+                {/* gender/age/bp not provided by GET /appointments */}
+                {/* TODO: populate once GET /consultations?doctorId=:id is confirmed */}
                 <p className="text-sm text-gray-500 mt-1">
-                  {selected.gender}, {selected.age} years · BP {selected.bp} · {selected.date}
+                  {selected.gender ?? '—'} · {selected.age != null ? `${selected.age} yrs` : '—'} · BP {selected.bp ?? '—'} · {selected.date}
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-4">
@@ -159,7 +213,9 @@ export default function HospitalDoctorConsultationsPage() {
                 <InfoCard
                   label={t('hospital.status')}
                   value={
-                    <span className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-full bg-white ${STATUS_BADGE[selected.status]}`}>
+                    <span
+                      className={`inline-flex px-2.5 py-1 text-xs font-semibold rounded-full bg-white ${STATUS_BADGE[selected.status]}`}
+                    >
                       {t(STATUS_KEY[selected.status] ?? selected.status)}
                     </span>
                   }
@@ -168,12 +224,20 @@ export default function HospitalDoctorConsultationsPage() {
             </div>
           ) : (
             <div className="flex flex-col items-center text-center px-8">
-              {/* Icon — large circle with pulse line, matches Figma */}
               <div
                 className="w-24 h-24 rounded-full flex items-center justify-center mb-5"
                 style={{ background: '#EBF5FF' }}
               >
-                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#00A2E8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="40"
+                  height="40"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#00A2E8"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                 </svg>
               </div>


### PR DESCRIPTION
	modified:   src/app/hospital/doctor/consultations/page.tsx
- Switch date source from `a.date` (undefined in API response) to `a.scheduledAt`
  (confirmed field name from DOCTOR_REMAINING_PAGES_API_GAPS.md)
- gender/age/bp are not provided by GET /appointments; render '—' instead of
  leaking undefined into the DOM
- diagnosis mapped from `a.diagnosisSummary` (may be absent in list response —
  confirmed only for GET /appointments/:id); defaults to '—'
- duration not provided by the appointments response; defaults to '—'
- Add TODO to switch to GET /consultations?doctorId=:id once confirmed in Swagger
- Add TODO comments on every unmapped field per DOCTOR_PORTAL_BACKEND_CONTRACT.md
- Extract mapping to a named function for readability
- Add error banner with Retry button in addition to inline error text

## Summary

<html>
<body>
<!--StartFragment--><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>What changed in <a href="vscode-webview://0ta2q5in3nhb8k5fce4ibj42cg8o33ls5g8dm67lh0ofo2hrf6q3/src/app/hospital/doctor/consultations/page.tsx" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">consultations/page.tsx</a>:</strong></p>
Problem | Fix
-- | --
a.date → always undefined | Changed to a.scheduledAt (confirmed field name from gaps doc)
{c.gender}, {c.age} years · BP {c.bp} → renders garbage when undefined | Replaced with {c.gender ?? '—'} · {c.age != null ? ... : '—'} · BP {c.bp ?? '—'}
diagnosis: a.diagnosisSummary with no fallback | a.diagnosisSummary ?? '—' + TODO noting it's only confirmed for single-appointment endpoint
duration shown blank | Hardcoded '—' + TODO
No error retry button | Added error banner with Retry button above the split panel
Mapping logic inlined in useEffect | Extracted to mapToConsultation() with TODO comment pointing to the contract doc

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Endpoint decision:</strong> <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /consultations?doctorId=:id</code> is <strong>not in Swagger</strong> (not in the confirmed list and not in the "missing" list in the gaps doc) → kept <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /appointments</code> with a <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">// TODO: switch to GET /consultations?doctorId=:id once confirmed available</code> comment at the fetch call.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Build: <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">✓ Compiled successfully</code> · Lint: clean.</p><!--EndFragment-->
</body>
</html>What changed in [consultations/page.tsx](vscode-webview://0ta2q5in3nhb8k5fce4ibj42cg8o33ls5g8dm67lh0ofo2hrf6q3/src/app/hospital/doctor/consultations/page.tsx):

Problem	Fix
a.date → always undefined	Changed to a.scheduledAt (confirmed field name from gaps doc)
{c.gender}, {c.age} years · BP {c.bp} → renders garbage when undefined	Replaced with {c.gender ?? '—'} · {c.age != null ? ... : '—'} · BP {c.bp ?? '—'}
diagnosis: a.diagnosisSummary with no fallback	a.diagnosisSummary ?? '—' + TODO noting it's only confirmed for single-appointment endpoint
duration shown blank	Hardcoded '—' + TODO
No error retry button	Added error banner with Retry button above the split panel
Mapping logic inlined in useEffect	Extracted to mapToConsultation() with TODO comment pointing to the contract doc
Endpoint decision: GET /consultations?doctorId=:id is not in Swagger (not in the confirmed list and not in the "missing" list in the gaps doc) → kept GET /appointments with a // TODO: switch to GET /consultations?doctorId=:id once confirmed available comment at the fetch call.

Build: ✓ Compiled successfully · Lint: clean.
## Changes

<!-- Bullet the key changes. Group by area/portal if it helps. -->

-

## Affected portals / areas

<!-- Tick all that apply. -->

- [ ] Patient
- [ ] Pharmacy
- [ ] Branch
- [ ] Staff
- [ ] Super-admin
- [ ] Shared / cross-cutting

## How to test

<!-- Concrete steps a reviewer can follow. List the screens/flows to check. -->

1.

## Checklist

- [ ] `npm run build` passes clean (type-check included)
- [ ] `npm run lint` passes
- [ ] New user-facing strings exist in `en`, `fr`, and `rw` (uncertain ones flagged `[REVIEW XX]`)
- [ ] Used design tokens / `StatusBadge` instead of raw hex where applicable
- [ ] Manually verified the affected screens in the browser
- [ ] No secrets, `.env.local`, or local-only notes committed

## Related issues

<!-- e.g. Closes #123 -->
